### PR TITLE
feat(review): make the closing note a thread the agent can answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,7 +40,9 @@ today, written as a starting point rather than a history.
 - **Presence** — *waiting* / *listening* / *working*, with a 5-minute stall threshold, so
   you always know whether a Send reaches a live agent or waits in a queue.
 - **Finish review**, which hands the whole batch over with coverage attached (*38/42 hunks
-  read, 2 files skipped*) and an optional closing note quoted verbatim to the agent.
+  read, 2 files skipped*) and an optional closing note. The note travels as a thread on the
+  whole changeset — it leads the agent's batch, and the agent replies to it like any other
+  thread.
 - **`diffo setup`**, which registers Diffo with Claude Code, Cursor, VS Code and Copilot
   CLI, writes a shared copy into the cross-tool `~/.agents/skills` directory that Codex,
   Gemini CLI, Amp, Goose and OpenCode read, and installs the generated

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -73,9 +73,10 @@ protocol. Because it is assembled per payload, an agent with no skill installed
 and no memory of this page still receives complete instructions.
 
 A `kind: "finish"` payload is the reviewer pressing **Finish review**: the whole
-batch at once, with coverage attached (`38/42 hunks read, 2 files skipped`) and any
-closing note quoted verbatim. It re-ships every thread that was sent, including
-ones already answered, and the prompt tells the agent not to answer those twice.
+batch at once, with coverage attached (`38/42 hunks read, 2 files skipped`). Any
+closing note leads that batch as its own thread on the whole changeset, with an id
+to reply to. It re-ships every thread that was sent, including ones already
+answered, and the prompt tells the agent not to answer those twice.
 
 ## Change or Question: the intent contract
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -121,8 +121,9 @@ open ──send──▶ sent ──agent replies──▶ addressed ──▶ r
 with a few honest extra bits: `codeChanged` (the anchored hunk's id rotated), `withheld`
 (a reviewer reply deliberately not handed over yet, stored rather than inferred, because
 "the last message is the reviewer's" is also true of a reply that *was* delivered),
-`unanswered` (the agent closed the batch without replying), and `sentAt`, which has to
-survive a restart because the queue's FIFO order is a promise.
+`unanswered` (the agent closed the batch without replying), `closingNote` (Finish's own
+thread, below), and `sentAt`, which has to survive a restart because the queue's FIFO order
+is a promise.
 
 `reconcile()` runs against the current hunk id set on every changeset change. Threads whose
 code is gone are **hidden, never deleted**: a stash or a branch switch empties the diff
@@ -130,6 +131,13 @@ for a minute and must not destroy a comment.
 
 `lastFinish` is one record, overwritten each time, never a history: the hunk ids that
 existed when you last pressed Finish. That's what "since last review" is computed from.
+
+A **closing note** typed into Finish becomes a real thread anchored to the changeset,
+flagged `closingNote` and flushed with the batch it closes. It was prose in the prompt
+once, which made it the one piece of a review with no way back: no thread, no id, nothing
+to reply to. As a thread it leads the batch, the agent answers it with `diffo reply`, and
+`undeliveredThreadIds` counts it as an answer still owed. A note typed over an emptied
+changeset has nowhere to anchor, so that one stays quoted prose.
 
 ## The delivery queue
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -71,8 +71,8 @@ its reply comes back into the same thread.
 When you're done reading, hit **Finish review** in the header.
 
 A preview shows exactly what will be sent: every thread, plus your coverage
-(`38/42 hunks read, 2 files skipped`). Add a closing note if you want; it appears at the
-top of what the agent receives.
+(`38/42 hunks read, 2 files skipped`). Add a closing note if you want — it goes out as a
+thread on the whole changeset, leading the batch, and the agent replies to it there.
 
 After you send:
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -385,6 +385,40 @@ export function createApp(
     )
   }
 
+  /**
+   * A closing note only becomes a thread while the changeset still has files to
+   * anchor it to — an empty diff would file it straight into the past, where the
+   * reviewer can't see it and the agent is never given it. In that case the note
+   * stays prose in the prompt (`buildFinishPrompt` quotes it when no thread carries
+   * it), which is all it ever was.
+   */
+  const notable = (coverage: Coverage): boolean =>
+    coverage.note !== undefined && (store?.get().files.length ?? 0) > 0
+
+  /** The preview must show the note the same way Finish will send it — a thread in
+   * the batch — without writing one for a review the reviewer may still walk away
+   * from. */
+  const projectClosingNote = (threads: ReviewThread[], coverage: Coverage): ReviewThread[] => {
+    if (!notable(coverage)) return threads
+    const at = new Date().toISOString()
+    return [
+      ...threads,
+      {
+        id: 'closing-note-preview',
+        anchor: { kind: 'changeset' },
+        state: 'sent',
+        closingNote: true,
+        codeContext: null,
+        codeChanged: false,
+        messages: [
+          { id: 'closing-note-preview-message', author: 'reviewer', text: coverage.note!, at },
+        ],
+        createdAt: at,
+        updatedAt: at,
+      },
+    ]
+  }
+
   const outgoing = (projected: ReviewThread[], before: ReviewThread[]): OutgoingThread[] =>
     projected
       .filter((t) => t.state === 'sent')
@@ -392,7 +426,9 @@ export function createApp(
         id: t.id,
         anchor: t.anchor,
         text: t.messages[0]?.text ?? '',
-        fresh: before.find((b) => b.id === t.id)?.state === 'open',
+        // Absent from `before` ⇒ this Finish is creating it (the closing note), which
+        // is as fresh as a thread that was merely open.
+        fresh: (before.find((b) => b.id === t.id)?.state ?? 'open') === 'open',
       }))
 
   app.post('/api/review/finish/preview', async (c) => {
@@ -400,7 +436,7 @@ export function createApp(
     const body = await c.req.json().catch(() => null)
     const coverage = parseCoverage(body?.coverage)
     const before = review.get().threads
-    const batch = activeThreads(projectFinish(before))
+    const batch = projectClosingNote(activeThreads(projectFinish(before)), coverage)
     return c.json({
       outgoing: outgoing(batch, before),
       prompt: buildFinishPrompt(
@@ -416,8 +452,9 @@ export function createApp(
     const body = await c.req.json().catch(() => null)
     const coverage = parseCoverage(body?.coverage)
     const deliver = body?.deliver !== false
-    const before = review.get().threads
-    const threads = review.finish(flushableIds(before))
+    // Before the flush, so the note rides the batch it closes rather than the next one.
+    if (notable(coverage)) review.closingNote(coverage.note!)
+    const threads = review.finish(flushableIds(review.get().threads))
     const batch = activeThreads(threads)
     review.recordFinish(
       (store?.get().files ?? []).flatMap((f) => f.hunks.map((h) => h.id)),

--- a/src/server/prompt.test.ts
+++ b/src/server/prompt.test.ts
@@ -167,6 +167,8 @@ describe('prompt context (A1)', () => {
   })
 
   it('the finish verdict leads: approve is stated before coverage, note quoted verbatim', () => {
+    // No thread carries the note — a finish recorded before closing notes were
+    // threads, or one over a changeset with nothing left to anchor to.
     const prompt = buildFinishPrompt(
       [],
       { repo, changeset: null },
@@ -182,6 +184,35 @@ describe('prompt context (A1)', () => {
     expect(prompt).toContain('> all good')
     expect(prompt).toContain('> merge it please')
     expect(prompt.indexOf('**approved**')).toBeLessThan(prompt.indexOf('Coverage:'))
+  })
+
+  it('the closing-note thread leads the batch, quoted once, with a reply id', () => {
+    const note = thread({
+      id: 't-note',
+      anchor: { kind: 'changeset' },
+      closingNote: true,
+      codeContext: null,
+      messages: [
+        { id: 'm-note', author: 'reviewer', text: 'solid overall', at: '2026-08-03T00:00:00Z' },
+      ],
+    })
+    const prompt = buildFinishPrompt(
+      [thread(), note],
+      { repo, changeset: null },
+      {
+        viewedHunks: 1,
+        totalHunks: 1,
+        skippedFiles: [],
+        note: 'solid overall',
+      },
+    )
+    expect(prompt).toContain('Thread 1 [their closing note on the whole review]')
+    expect(prompt).toContain('id: t-note')
+    // Pointed at from the top rather than quoted twice.
+    expect(prompt).toContain('Their closing note is Thread 1 below')
+    expect(prompt.match(/solid overall/g)).toHaveLength(1)
+    expect(prompt).toContain('The closing note speaks for the whole review')
+    expect(prompt.indexOf('id: t-note')).toBeLessThan(prompt.indexOf('id: t-1'))
   })
 
   it('request-changes says the review is not done; a plain comment adds no verdict line', () => {

--- a/src/server/prompt.ts
+++ b/src/server/prompt.ts
@@ -157,10 +157,16 @@ const INTENT_CONTRACT: Record<ThreadIntent, string> = {
 const UNLABELED_CONTRACT =
   '- Unlabeled threads: judge from the text — a question wants an answer, not an edit.'
 
+/** The closing note is the reviewer summing up, so it earns an answer even when it
+ * asks nothing — a note with no reply is the review's one dead end. */
+const CLOSING_CONTRACT =
+  '- The closing note speaks for the whole review: read it first, and reply to it — briefly if it only sums up, in full if it asks something.'
+
 export function intentContract(threads: readonly ReviewThread[]): string[] {
-  const present = new Set(threads.map((t) => t.intent))
+  const present = new Set(threads.filter((t) => !t.closingNote).map((t) => t.intent))
   const lines = THREAD_INTENTS.filter((i) => present.has(i)).map((i) => INTENT_CONTRACT[i])
   if (present.has(undefined)) lines.push(UNLABELED_CONTRACT)
+  if (threads.some((t) => t.closingNote)) lines.push(CLOSING_CONTRACT)
   return lines
 }
 
@@ -277,9 +283,11 @@ function threadBlock(thread: ReviewThread, index: number): string {
   // responding to something the agent said, not filing new feedback.
   const label = startedByAgent(thread)
     ? ' [your comment — the reviewer replied]'
-    : thread.intent
-      ? ` [${INTENT_LABEL[thread.intent]}]`
-      : ''
+    : thread.closingNote
+      ? ' [their closing note on the whole review]'
+      : thread.intent
+        ? ` [${INTENT_LABEL[thread.intent]}]`
+        : ''
   const again = thread.unanswered ? ' — YOU NEVER ANSWERED THIS' : ''
   const parts = [
     `### Thread ${index + 1}${label} — ${describeAnchor(thread.anchor)}${again}`,
@@ -335,7 +343,11 @@ export function buildFinishPrompt(
   coverage: Coverage,
 ): string {
   const repo = ctx.repo
-  const actionable = threads.filter((t) => t.state === 'sent')
+  const sent = threads.filter((t) => t.state === 'sent')
+  // The closing note leads the batch: it is what the reviewer would say first if
+  // they were in the room, and it frames every thread under it.
+  const closing = sent.find((t) => t.closingNote)
+  const actionable = closing ? [closing, ...sent.filter((t) => t !== closing)] : sent
   const changed = coverage.changedFiles ?? []
   const commented = coverage.commentedUnread ?? []
   const filtered = coverage.filteredOut ?? []
@@ -361,10 +373,16 @@ export function buildFinishPrompt(
       : coverage.verdict === 'request-changes'
         ? 'Verdict: **changes requested** — do not treat this review as done until the threads below are addressed.'
         : null
+  // The note is a thread now, quoted once in its own block — pointed at from up
+  // here rather than repeated. Quoted in full only when no thread carries it: a
+  // finish recorded before closing notes were threads, or one taken over an empty
+  // changeset that had nowhere to anchor it.
   const noteLines =
-    coverage.note !== undefined
-      ? ['Their closing note:', ...coverage.note.split('\n').map((l) => `> ${l}`)]
-      : []
+    coverage.note === undefined
+      ? []
+      : closing
+        ? ['Their closing note is Thread 1 below — answer it there, like any other thread.']
+        : ['Their closing note:', ...coverage.note.split('\n').map((l) => `> ${l}`)]
   const owed = actionable.filter((t) => t.unanswered)
   const owedLines =
     owed.length > 0

--- a/src/server/review-api.test.ts
+++ b/src/server/review-api.test.ts
@@ -3,7 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it } from 'vitest'
-import { type ReviewThread, undeliveredThreadIds } from '../shared/review.js'
+import { type OutgoingThread, type ReviewThread, undeliveredThreadIds } from '../shared/review.js'
 import { DiffoDb } from './db.js'
 import { DeliveryQueue } from './delivery.js'
 import { createApp } from './index.js'
@@ -249,9 +249,20 @@ describe('review API', () => {
         note: '  merge it please  ',
       },
     })
-    const body = (await res.json()) as { prompt: string }
+    const body = (await res.json()) as { threads: ReviewThread[]; prompt: string }
     expect(body.prompt).toContain('**approved**')
-    expect(body.prompt).toContain('> merge it please')
+    expect(body.prompt).toContain('merge it please')
+
+    // The note is a thread of the reviewer's, sent with the batch it closes — so the
+    // agent has an id to reply to, and the queue counts it as an answer still owed.
+    const note = body.threads.find((t) => t.closingNote)!
+    expect(note.anchor).toEqual({ kind: 'changeset' })
+    expect(note.messages).toEqual([
+      expect.objectContaining({ author: 'reviewer', text: 'merge it please' }),
+    ])
+    expect(note.state).toBe('sent')
+    expect(undeliveredThreadIds(body.threads)).toContain(note.id)
+    expect(body.prompt).toContain(`id: ${note.id}`)
 
     const junk = (await (
       await post(app, '/api/review/finish', {
@@ -263,8 +274,72 @@ describe('review API', () => {
           note: '  ',
         },
       })
-    ).json()) as { prompt: string }
+    ).json()) as { threads: ReviewThread[]; prompt: string }
     expect(junk.prompt).not.toContain('Verdict:')
+    // A blank note adds no second thread — only the first finish's note is there.
+    expect(junk.threads.filter((t) => t.closingNote)).toHaveLength(1)
+  })
+
+  it('the closing note leads the batch, and the agent can reply to it', async () => {
+    const { app } = setup()
+    await post(app, '/api/review/threads', {
+      anchor: { kind: 'changeset' },
+      text: 'why 42?',
+      intent: 'question',
+    })
+    const finished = (await (
+      await post(app, '/api/review/finish', {
+        coverage: {
+          viewedHunks: 1,
+          totalHunks: 1,
+          skippedFiles: [],
+          note: 'ship it after the nit',
+        },
+      })
+    ).json()) as { threads: ReviewThread[]; prompt: string }
+
+    // Thread 1 of the prompt, quoted once — not repeated as a preamble block.
+    expect(finished.prompt).toContain('Thread 1 [their closing note on the whole review]')
+    expect(finished.prompt.match(/ship it after the nit/g)).toHaveLength(1)
+    expect(finished.prompt).toContain('Their closing note is Thread 1 below')
+
+    const note = finished.threads.find((t) => t.closingNote)!
+    const replied = (await post(app, `/api/review/threads/${note.id}/messages`, {
+      author: 'agent',
+      text: 'will do',
+    })) as Response
+    expect(replied.status).toBe(200)
+    const { thread } = (await replied.json()) as { thread: ReviewThread }
+    expect(thread.messages.at(-1)).toMatchObject({ author: 'agent', text: 'will do' })
+    expect(undeliveredThreadIds([thread])).toEqual([])
+  })
+
+  it('the finish preview shows the closing note as one of the outgoing threads', async () => {
+    const { app, review } = setup()
+    const res = await post(app, '/api/review/finish/preview', {
+      coverage: { viewedHunks: 1, totalHunks: 1, skippedFiles: [], note: 'one nit, then ship' },
+    })
+    const body = (await res.json()) as { outgoing: OutgoingThread[]; prompt: string }
+    expect(body.outgoing).toEqual([
+      expect.objectContaining({
+        anchor: { kind: 'changeset' },
+        text: 'one nit, then ship',
+        fresh: true,
+      }),
+    ])
+    expect(body.prompt).toContain('their closing note on the whole review')
+    // A preview writes nothing — the reviewer can still walk away.
+    expect(review.get().threads).toEqual([])
+  })
+
+  it('a closing note survives a restart as a thread', async () => {
+    const { app, root } = setup()
+    await post(app, '/api/review/finish', {
+      coverage: { viewedHunks: 1, totalHunks: 1, skippedFiles: [], note: 'read it all, one nit' },
+    })
+    const reopened = new ReviewStore(root, makeDb(root), { kind: 'working-tree' })
+    const note = reopened.get().threads.find((t) => t.closingNote)
+    expect(note?.messages[0]?.text).toBe('read it all, one nit')
   })
 
   it('finish leaves behind the threads whose changeset is behind you', async () => {
@@ -570,6 +645,26 @@ describe('the pull loop', () => {
     expect(payload.prompt).toContain('note a')
     expect(payload.prompt).toContain('note b')
     expect((payload.threadIds as string[]).length).toBe(2)
+  })
+
+  it('the poll rebuilds the finish payload with the closing note as a thread id', async () => {
+    const { app } = setup()
+    const finished = (await (
+      await post(app, '/api/review/finish', {
+        coverage: { viewedHunks: 1, totalHunks: 1, skippedFiles: [], note: 'nothing blocking' },
+      })
+    ).json()) as { threads: ReviewThread[] }
+    const note = finished.threads.find((t) => t.closingNote)!
+
+    // Rebuilt from the stored coverage, so this is the path a poll that arrives after a
+    // restart takes — the note must come back as an answerable thread, not as prose.
+    const payload = await pollResult(
+      await app.request('/api/agent/poll', { headers: { 'x-diffo-agent': 'cli' } }),
+    )
+    expect(payload.kind).toBe('finish')
+    expect(payload.threadIds).toEqual([note.id])
+    expect(payload.prompt).toContain('their closing note on the whole review')
+    expect(payload.prompt).not.toContain('Nothing to act on')
   })
 
   it('a reply to a sent thread flows through the poll; replies to open threads stay local', async () => {

--- a/src/server/review.ts
+++ b/src/server/review.ts
@@ -80,7 +80,7 @@ export class ReviewStore {
     author: Author = 'reviewer',
   ): ReviewThread {
     const now = new Date().toISOString()
-    const thread: ReviewThread = {
+    return this.insert({
       id: randomUUID(),
       anchor,
       state: 'open',
@@ -90,7 +90,32 @@ export class ReviewStore {
       messages: [{ id: randomUUID(), author, text, at: now }],
       createdAt: now,
       updatedAt: now,
-    }
+    })
+  }
+
+  /**
+   * The closing note of a Finish round, as a thread. Anchored to the changeset
+   * and opened in the reviewer's voice, so it travels the ordinary path: the
+   * agent replies to it with `diffo reply`, the queue counts it as feedback
+   * still owed an answer, and the reviewer sees their own summing-up in the rail
+   * beside everything else they said.
+   */
+  closingNote(text: string): ReviewThread {
+    const now = new Date().toISOString()
+    return this.insert({
+      id: randomUUID(),
+      anchor: { kind: 'changeset' },
+      state: 'open',
+      closingNote: true,
+      codeContext: null,
+      codeChanged: false,
+      messages: [{ id: randomUUID(), author: 'reviewer', text, at: now }],
+      createdAt: now,
+      updatedAt: now,
+    })
+  }
+
+  private insert(thread: ReviewThread): ReviewThread {
     this.state = { ...this.state, threads: [...this.state.threads, thread] }
     this.commit()
     return thread
@@ -507,6 +532,7 @@ function normalizeThread(value: unknown, now: string): ReviewThread | null {
     codeContext: typeof t.codeContext === 'string' ? t.codeContext : null,
     codeChanged: t.codeChanged === true,
     ...(t.unanswered === true ? { unanswered: true } : {}),
+    ...(t.closingNote === true ? { closingNote: true as const } : {}),
     ...(typeof t.sentAt === 'string' ? { sentAt: t.sentAt } : {}),
     messages,
     createdAt: typeof t.createdAt === 'string' ? t.createdAt : now,

--- a/src/shared/review.ts
+++ b/src/shared/review.ts
@@ -33,6 +33,11 @@ export interface ReviewThread {
   /** The agent concluded the batch this thread went out in without replying —
    * not "slow", so the UI must stop waiting on it. */
   unanswered?: boolean
+  /** The reviewer's closing note for one Finish round, kept as a thread rather
+   * than as prose in the prompt: a note the agent cannot reply to is the one
+   * piece of the review with no way back. Anchored to the changeset, created by
+   * Finish, and flushed in that same batch. */
+  closingNote?: true
   /** ISO, stamped on the transition to `sent`. The queue's line is FIFO by this,
    * so it has to survive a restart. */
   sentAt?: string

--- a/src/ui/components/FinishReview.tsx
+++ b/src/ui/components/FinishReview.tsx
@@ -306,7 +306,7 @@ export function FinishReview({
           <div className="fin-verdict-consequence">{CONSEQUENCE[verdict]}</div>
           <textarea
             className="fin-note"
-            placeholder="Add a closing note (optional) — quoted verbatim at the top of the agent's prompt"
+            placeholder="Add a closing note (optional) — sent as a thread on the changeset, so the agent can reply to it"
             value={note}
             rows={2}
             onChange={(e) => setNote(e.target.value)}

--- a/src/ui/components/Threads.test.tsx
+++ b/src/ui/components/Threads.test.tsx
@@ -306,6 +306,27 @@ describe('ThreadCard', () => {
     expect(screen.queryByText(/couldn't reach the clipboard/)).toBeNull()
   })
 
+  it('a closing note is badged as one, and waits on the agent like any thread', () => {
+    render(
+      <ThreadCard
+        thread={thread({
+          anchor: { kind: 'changeset' },
+          state: 'sent',
+          closingNote: true,
+          codeContext: null,
+          messages: [
+            { id: 'm1', author: 'reviewer', text: 'solid overall', at: '2026-08-03T00:00:00Z' },
+          ],
+        })}
+        actions={actions()}
+      />,
+    )
+    expect(screen.getByText('closing note')).toBeTruthy()
+    expect(screen.getByText('solid overall')).toBeTruthy()
+    // Sent, so it is the agent's move — no Send button left on it.
+    expect(screen.queryByText('Send')).toBeNull()
+  })
+
   it('a resolved thread collapses to one line, and expands on click', () => {
     render(
       <ThreadCard thread={thread({ state: 'resolved', codeChanged: true })} actions={actions()} />,

--- a/src/ui/components/Threads.tsx
+++ b/src/ui/components/Threads.tsx
@@ -233,6 +233,7 @@ export function ThreadCard({
   // own: on a two-line thread that band was taller than the comment it labelled.
   const marks = (
     <span className="thread-marks">
+      {thread.closingNote && <span className="thread-badge">closing note</span>}
       {thread.codeChanged && (
         <span className="thread-badge">
           <Icon name="alert" size="sm" /> code changed since this comment


### PR DESCRIPTION
The gap
The closing note typed into Finish review lived only in Coverage.note — quoted into the prompt preamble and nothing else. No thread, no id, nothing in the delivery queue's owed-answer set. So the one place the reviewer sums up the whole review was the one place the agent could not reply.

Worst case: a Finish whose only feedback was a note handed the agent threadIds: [] and a prompt reading "No open review threads — nothing to act on."

The change
The note becomes a real reviewer thread anchored to the changeset, flagged closingNote, flushed with the batch it closes.

ReviewStore.closingNote() creates it; the flag survives a restart through normalizeThread.
/api/review/finish creates it before the flush, so it rides that batch — and only while the changeset still has files to anchor to.
/api/review/finish/preview projects the same thread without writing one, so the peeked prompt and the outgoing list match what Finish will send. fresh now reads a thread absent from before as new rather than re-sent.
The prompt hoists it to Thread 1, labeled [their closing note on the whole review], and the preamble points at it instead of repeating it.
One contract line: "The closing note speaks for the whole review: read it first, and reply to it — briefly if it only sums up, in full if it asks something."
UI: a closing note badge on the card; the Finish placeholder no longer promises "quoted verbatim at the top of the agent's prompt".
Kept deliberately: Coverage.note and the old quote block, as the fallback for a note no thread carries — a finish recorded before this change, or one over an emptied changeset.

Verification
Reviewed with Diffo itself. A closing note came back as Thread 1 with an id, diffo reply landed the answer inside it, and the browser shows it badged as a closing note on the changeset.

865 tests pass; typecheck, biome and the docs build are clean. Docs updated in CHANGELOG.md, docs/architecture.md, docs/agents.md, docs/tutorial.md.

Noticed, not fixed
normalizeThread drops withheld and deliveredThrough on reload, despite withheld being documented as stored rather than inferred — a held reply reads as delivered after a restart.
The Finish modal's live preview still doesn't include the note (the query is keyed on coverage, so wiring it in means debouncing keystrokes). The placeholder states the behavior in words instead.