### PR TITLE
docs: align everything with the published package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,3 @@
-> [!IMPORTANT]
-> **Diffo is pre-release.** The loop works end to end and this repo is reviewed with it
-> daily. The skill installs from this repository; the CLI it runs comes from npm as
-> **`@diffohq/diffo`** — scoped because the bare `diffo` name belongs to an unrelated
-> package. See [Status](#status) for what works today.
-
 <div align="center">
 
 <a href="https://diffohq.github.io/diffo/">
@@ -23,6 +17,7 @@ come back as fixes.
 [Quick start](#quick-start) · [Why Diffo](#why-diffo) · [Docs](#docs) · [Status](#status) · [Contributing](#contributing)
 
 [![CI](https://img.shields.io/github/actions/workflow/status/DiffoHQ/diffo/ci.yml?branch=main&label=CI)](https://github.com/DiffoHQ/diffo/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/%40diffohq%2Fdiffo?label=npm&color=cb3837)](https://www.npmjs.com/package/@diffohq/diffo)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%E2%89%A5%2024-brightgreen)](#quick-start)
 [![Docs](https://img.shields.io/badge/docs-diffo-8b5cf6)](https://diffohq.github.io/diffo/)
@@ -254,7 +249,8 @@ we commit to: **anything that runs on your machine for one reviewer is core.**
 
 ## Status
 
-What works today:
+Diffo is pre-1.0: the loop below works end to end — this repo is reviewed with it
+daily — and the edges are still moving. What works today:
 
 - [x] [Live review of any changeset](https://diffohq.github.io/diffo/guide/how-it-works): the working tree, or anything since `--base`.
 - [x] [The comment loop](https://diffohq.github.io/diffo/guide/the-loop): threads that reach the session that wrote the code.

--- a/docs/.vitepress/config.ts
+++ b/docs/.vitepress/config.ts
@@ -62,7 +62,10 @@ export default defineConfig({
         ],
       },
     ],
-    socialLinks: [{ icon: 'github', link: 'https://github.com/DiffoHQ/diffo' }],
+    socialLinks: [
+      { icon: 'github', link: 'https://github.com/DiffoHQ/diffo' },
+      { icon: 'npm', link: 'https://www.npmjs.com/package/@diffohq/diffo' },
+    ],
     search: { provider: 'local' },
     editLink: {
       pattern: 'https://github.com/DiffoHQ/diffo/edit/main/docs/:path',

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -22,8 +22,9 @@ first, and the PR is still there to open when you're done.
 
 ### Can I review a pull request with it?
 
-Not yet, but it's on the [roadmap](https://github.com/DiffoHQ/diffo#roadmap). Today the changeset is your working
-tree (the default) or everything since a fork point (`--base main`).
+Not yet, but it's planned — the [Status section](https://github.com/DiffoHQ/diffo#status)
+tracks what works today. For now the changeset is your working tree (the default) or
+everything since a fork point (`--base main`).
 
 ### Why Node 24?
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -51,8 +51,8 @@ its fixes update the diff live while you read.
 And the plain diff viewer needs no install at all: `npx -y @diffohq/diffo` inside
 any repo opens the browser on your working tree vs HEAD.
 
-::: warning Not yet on npm
-Until `diffo` is published, run from a clone:
+::: details Running from a clone instead
+Contributors (or anyone avoiding `npx`) can run the CLI straight out of a checkout:
 
 ```bash
 git clone https://github.com/DiffoHQ/diffo.git && cd diffo


### PR DESCRIPTION
## What this changes

Aligns the README and docs with the published npm package, in both directions —
removing what the publish made stale, adding what it made possible.

- The README's IMPORTANT banner is gone. It existed to explain an unpublished
  npm package; the pre-release honesty now lives where it belongs — the Status
  section (which picks up the banner's daily-dogfooding line) and the status
  badge. The README now opens with the pitch, not a warning.
- An npm version badge joins the badge row (live from the registry, links to
  the package), and the docs site's nav gains the npm icon next to GitHub.
- Getting started still warned "Not yet on npm — run from a clone", directly
  under the npx instructions it contradicted. Now a collapsed
  contributor-framed "Running from a clone" details block.
- The FAQ linked to a #roadmap anchor the README has never had; it now points
  at the Status section.

## How you tested it

- [x] `pnpm docs:build` (dead-link gate) and `pnpm lint`
- [x] Every rewritten/added URL curl-verified against the live site and shields