### PR TITLE
ci: publish to npm from Actions with provenance

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish
+
+# Publishing runs here, not on a laptop, so every release carries npm provenance:
+# a signed attestation binding the tarball to the exact commit and workflow that
+# built it. Auth is npm "trusted publishing" (OIDC) — there is no NPM_TOKEN to
+# store, leak, or rotate. One-time pairing lives in the package's settings on
+# npmjs.com: Trusted Publisher → GitHub Actions → DiffoHQ/diffo, publish.yml.
+on:
+  push:
+    tags: ['v*']
+
+# id-token lets npm verify the workflow's OIDC identity; nothing here may write
+# to the repo.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: pnpm/action-setup@v6
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # Trusted publishing needs npm ≥ 11.5.1; the npm bundled with the runner's
+      # Node has lagged that before. Pinning latest keeps the OIDC exchange from
+      # silently degrading into "no token found".
+      - run: npm install -g npm@latest
+
+      - run: pnpm install --frozen-lockfile
+
+      # A tag that disagrees with package.json would publish a version whose
+      # source no one can find again. Refuse before npm gets involved.
+      - name: Verify tag matches package.json
+        run: |
+          tag="${GITHUB_REF_NAME#v}"
+          pkg="$(node -p "require('./package.json').version")"
+          if [ "$tag" != "$pkg" ]; then
+            echo "tag v$tag does not match package.json version $pkg" >&2
+            exit 1
+          fi
+
+      # prepublishOnly runs the full `pnpm check` (typecheck, test, build, lint,
+      # docs), so the published dist is built by this same job. --provenance is
+      # implied by trusted publishing but stated so a misconfigured setup fails
+      # loudly instead of publishing unattested.
+      - run: npm publish --provenance

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,13 @@ Until 1.0, minor versions may break things. When they do, the entry says how to 
 
 ## [Unreleased]
 
-Nothing yet.
+### Changed
+
+- Releases are now published to npm from GitHub Actions with
+  [provenance](https://docs.npmjs.com/generating-provenance-statements): every
+  tarball carries a signed attestation binding it to the exact commit and
+  workflow run that built it, verifiable on the npm package page. Nothing
+  changes for users — same package, now with a checkable paper trail.
 
 ## [0.0.1] — 2026-08-25
 


### PR DESCRIPTION
ci: publish to npm from Actions with provenance

Moves npm publishing off the laptop and into CI. Pushing a v* tag now runs publish.yml, which re-runs the full pnpm check via prepublishOnly, refuses to publish if the tag disagrees with package.json, and publishes with npm publish --provenance under npm trusted publishing (OIDC) — no npm token stored in secrets or anywhere else.

Every release from now on carries a signed attestation binding the tarball to the exact commit and workflow run that built it, visible on the npm version page.

Requires a one-time Trusted Publisher pairing on npmjs.com (package Settings → Trusted Publisher → GitHub Actions → DiffoHQ/diffo, publish.yml) before the first CI publish.