### PR TITLE
release: 0.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ Until 1.0, minor versions may break things. When they do, the entry says how to 
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [0.0.2] — 2026-08-26
+
 ### Changed
 
 - Releases are now published to npm from GitHub Actions with
@@ -73,5 +77,6 @@ shipped in it, written as a starting point rather than a history.
 - **Guided reading** — splitting a large change into an ordered sequence of small,
   reviewable sections — is designed but not built.
 
-[Unreleased]: https://github.com/DiffoHQ/diffo/compare/main...HEAD
+[Unreleased]: https://github.com/DiffoHQ/diffo/compare/v0.0.2...HEAD
+[0.0.2]: https://github.com/DiffoHQ/diffo/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/DiffoHQ/diffo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diffohq/diffo",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Local, live code review for the AI age — read what the agent wrote and send feedback straight back",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "diffo",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Local, live code review for the AI age — read what the agent wrote and send feedback straight back",
   "author": {
     "name": "DiffoHQ",


### PR DESCRIPTION
release: 0.0.2

Version bump to 0.0.2. Sole change since 0.0.1: releases now publish to npm from GitHub Actions with provenance (trusted publishing / OIDC) — no user-facing changes to the package itself.

This is the first release that will go through the new publish.yml pipeline.