### PR TITLE
fix: match the renamed package in the version walk-up

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,12 @@ Until 1.0, minor versions may break things. When they do, the entry says how to 
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- The CLI knows its own version again. Since the rename to `@diffohq/diffo`,
+  every published build reported `0.0.0` (`diffo --version`, the server
+  handshake), so a newer CLI would reuse a running server from an older build
+  instead of replacing it.
 
 ## [0.0.2] — 2026-08-26
 

--- a/src/version.test.ts
+++ b/src/version.test.ts
@@ -1,0 +1,16 @@
+import { readFileSync } from 'node:fs'
+import { describe, expect, it } from 'vitest'
+import { VERSION } from './version.js'
+
+describe('VERSION', () => {
+  // The walk-up matches package.json by name, so a package rename silently
+  // drops every build to the 0.0.0 fallback — which the CLI reads as "same
+  // build as any other", so stale servers stop being replaced. 0.0.1 and
+  // 0.0.2 shipped that way.
+  it('reports the real package version, not the fallback', () => {
+    const pkg = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf-8')) as {
+      version: string
+    }
+    expect(VERSION).toBe(pkg.version)
+  })
+})

--- a/src/version.ts
+++ b/src/version.ts
@@ -19,7 +19,7 @@ export const VERSION: string = (() => {
         name?: string
         version?: string
       }
-      if (pkg.name === 'diffo' && typeof pkg.version === 'string') return pkg.version
+      if (pkg.name === '@diffohq/diffo' && typeof pkg.version === 'string') return pkg.version
     } catch {
       // keep climbing
     }


### PR DESCRIPTION
fix: match the renamed package in the version walk-up

version.ts locates its own package.json by name, and the check still said 'diffo' after the rename to @diffohq/diffo — so it never matched, and every published build (0.0.1 and 0.0.2) fell back to reporting 0.0.0. Beyond diffo --version being wrong, the CLI uses that version to decide whether a running server is from a stale build: with every build claiming 0.0.0, a newer CLI reuses an old server instead of replacing it.

One-line fix plus a regression test that pins VERSION to package.json's actual version, so a future rename fails the suite instead of silently degrading.