### PR TITLE
fix: catch a review that landed while no server was watching

### DIFF
--- a/src/server/delivery.test.ts
+++ b/src/server/delivery.test.ts
@@ -51,6 +51,49 @@ describe('DeliveryQueue', () => {
     expect(q.take()).toBeNull()
   })
 
+  it('a cleared notice wakes a waiting attach and is consumed by its confirm', async () => {
+    const q = new DeliveryQueue()
+    const attached = q.attach()
+    q.enqueueCleared()
+    expect(await attached).toBe('data')
+    const snapshot = q.take()!
+    expect(snapshot).toEqual({ kind: 'cleared' })
+    q.confirm(snapshot, [])
+    expect(q.take()).toBeNull()
+    // No reply is owed for a heads-up: the agent parks in the re-poll grace,
+    // never in an awaiting-reply batch that would read as stalled.
+    expect(q.presence()).toBe('working')
+    expect(q.currentBatch()).toBeNull()
+  })
+
+  it('real feedback outranks the heads-up, which survives until its own turn', () => {
+    const q = new DeliveryQueue()
+    q.enqueueCleared()
+    q.enqueueThreads(['t1'])
+    const first = q.take()!
+    expect(first).toMatchObject({ kind: 'threads', threadIds: ['t1'] })
+    q.confirm(first, ['t1'])
+    expect(q.take()).toEqual({ kind: 'cleared' })
+  })
+
+  it('clearing twice before a poll still owes exactly one heads-up', () => {
+    const q = new DeliveryQueue()
+    q.enqueueCleared()
+    q.enqueueCleared()
+    const snapshot = q.take()!
+    q.confirm(snapshot, [])
+    expect(q.take()).toBeNull()
+  })
+
+  it('a cleared notice is scoped — a branch switch parks it like any feedback', () => {
+    const q = new DeliveryQueue()
+    q.enqueueCleared()
+    q.rescope('other')
+    expect(q.take()).toBeNull()
+    q.rescope('')
+    expect(q.take()).toEqual({ kind: 'cleared' })
+  })
+
   it('a newer attach supersedes the old one', async () => {
     const q = new DeliveryQueue()
     const first = q.attach()

--- a/src/server/delivery.ts
+++ b/src/server/delivery.ts
@@ -55,10 +55,15 @@ export type AttachOutcome = 'data' | 'superseded' | 'ended' | 'gone'
 export type Snapshot =
   | { kind: 'threads'; threadIds: string[] }
   | { kind: 'finish'; coverage: Coverage; absorbedThreadIds: string[] }
+  | { kind: 'cleared' }
 
 interface ScopePending {
   threads: Set<string>
   finish: Coverage | null
+  /** The reviewer started the review over — the agent is owed a heads-up (and
+   * a chance to post a fresh guide). Rides behind real feedback: take() only
+   * surfaces it once nothing else is pending. */
+  cleared: boolean
 }
 
 export class DeliveryQueue {
@@ -182,7 +187,7 @@ export class DeliveryQueue {
   private bucket(): ScopePending {
     let bucket = this.buckets.get(this.scope)
     if (!bucket) {
-      bucket = { threads: new Set(), finish: null }
+      bucket = { threads: new Set(), finish: null, cleared: false }
       this.buckets.set(this.scope, bucket)
     }
     return bucket
@@ -328,6 +333,15 @@ export class DeliveryQueue {
     this.wake()
   }
 
+  /** The reviewer cleared the review. A boolean, not a queue: clearing twice
+   * before a poll still owes exactly one heads-up. */
+  enqueueCleared(): void {
+    this.bucket().cleared = true
+    const queued = this.waiter === null
+    this.wake()
+    if (queued) this.notify()
+  }
+
   drop(threadId: string): void {
     for (const bucket of this.buckets.values()) bucket.threads.delete(threadId)
     this.deliveredAt.delete(threadId)
@@ -394,7 +408,9 @@ export class DeliveryQueue {
 
   private hasPending(): boolean {
     const bucket = this.buckets.get(this.scope)
-    return bucket !== undefined && (bucket.threads.size > 0 || bucket.finish !== null)
+    return (
+      bucket !== undefined && (bucket.threads.size > 0 || bucket.finish !== null || bucket.cleared)
+    )
   }
 
   private wake(): void {
@@ -417,12 +433,24 @@ export class DeliveryQueue {
       }
     }
     if (bucket.threads.size > 0) return { kind: 'threads', threadIds: [...bucket.threads] }
+    // Real feedback outranks the heads-up: a cleared notice only surfaces once
+    // nothing else is owed, and survives in the bucket until then.
+    if (bucket.cleared) return { kind: 'cleared' }
     return null
   }
 
   /** The poll response for this snapshot was fully written — NOW it counts as
    * delivered. Clears exactly what the snapshot covered. */
   confirm(snapshot: Snapshot, deliveredThreadIds: string[]): void {
+    if (snapshot.kind === 'cleared') {
+      // No batch, no reply owed: the agent may post a guide and re-poll, which
+      // is what the grace window already models.
+      const bucket = this.buckets.get(this.scope)
+      if (bucket) bucket.cleared = false
+      this.armGrace()
+      this.notify()
+      return
+    }
     for (const bucket of this.buckets.values()) {
       if (snapshot.kind === 'finish') {
         if (bucket.finish === snapshot.coverage) bucket.finish = null

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -32,6 +32,7 @@ import {
 import { IdleMonitor, resolveIdleTimeoutMs } from './idle.js'
 import { maintainLanded } from './landed.js'
 import {
+  buildClearedPrompt,
   buildCoalescedPrompt,
   buildFinishPrompt,
   buildThreadPrompt,
@@ -296,8 +297,13 @@ export function createApp(
   // Declared before the `:id` route so the bare path isn't swallowed by it.
   app.delete('/api/review/threads', (c) => {
     if (!review) return c.json({ error: 'review unavailable' }, 503)
+    const before = review.get()
+    const hadRound = before.threads.length > 0 || before.lastFinish !== undefined
     const removed = review.reset()
     for (const id of removed) queue?.drop(id)
+    // The fresh round may already be on screen, guideless — wake the polling
+    // agent with the heads-up so it can orient the reviewer with a new guide.
+    if (hadRound && (store?.get().files.length ?? 0) > 0) queue?.enqueueCleared()
     return c.json({ removed: removed.length })
   })
 
@@ -483,6 +489,14 @@ export function createApp(
 
   const pollPayload = (snapshot: Snapshot) => {
     const threads = review?.get().threads ?? []
+    if (snapshot.kind === 'cleared') {
+      return {
+        status: 'feedback' as const,
+        kind: 'cleared' as const,
+        threadIds: [] as string[],
+        prompt: buildClearedPrompt({ repo: repoInfo(), changeset: store?.get() ?? null }),
+      }
+    }
     if (snapshot.kind === 'finish') {
       const batch = activeThreads(threads)
       const actionable = batch.filter((t) => t.state === 'sent').map((t) => t.id)
@@ -855,8 +869,8 @@ export function startServer(options: ServerContext & { port: number }) {
       isAncestor(options.root, ancestor, descendant),
     subject: (sha: string) => getCommitSubject(options.root, sha),
   }
-  const checkLanded = (hasFiles: boolean) => {
-    if (maintainLanded(review, hasFiles, landedGit) === 'stamped') {
+  const checkLanded = (hasFiles: boolean, hunkIds: ReadonlySet<string>) => {
+    if (maintainLanded(review, hasFiles, hunkIds, landedGit) === 'stamped') {
       const landed = review.get().landed
       if (landed) log(`changeset landed in ${landed.sha.slice(0, 7)} — offering a fresh review`)
     }
@@ -870,13 +884,15 @@ export function startServer(options: ServerContext & { port: number }) {
     queue.rescope(changeset.repo.branch)
     if (review.scope.branch !== before)
       log(`branch ${before || 'detached'} → ${changeset.repo.branch || 'detached'}`)
-    review.reconcile(new Set(changeset.files.flatMap((f) => f.hunks.map((h) => h.id))))
-    checkLanded(changeset.files.length > 0)
+    const hunkIds = new Set(changeset.files.flatMap((f) => f.hunks.map((h) => h.id)))
+    review.reconcile(hunkIds)
+    checkLanded(changeset.files.length > 0, hunkIds)
   })
-  review.reconcile(new Set(store.get().files.flatMap((f) => f.hunks.map((h) => h.id))))
+  const startupHunkIds = new Set(store.get().files.flatMap((f) => f.hunks.map((h) => h.id)))
+  review.reconcile(startupHunkIds)
   // Startup runs the same check: the commit that landed this review may have
   // happened while no server was watching (the idle reap makes that ordinary).
-  checkLanded(store.get().files.length > 0)
+  checkLanded(store.get().files.length > 0, startupHunkIds)
   const idleTimeoutMs = resolveIdleTimeoutMs(process.env)
   let idle: IdleMonitor | undefined
   // The queue's presence is deliberately not consulted: a delivered-but-unanswered

--- a/src/server/landed.test.ts
+++ b/src/server/landed.test.ts
@@ -28,6 +28,10 @@ function makeStore(root: string): ReviewStore {
 
 const anchor: Anchor = { kind: 'hunk', hunkId: 'h1', path: 'src/a.ts', side: 'new', line: 3 }
 
+/** The reviewed diff, still carrying the commented hunk. */
+const withHunks = new Set(['h1'])
+const noHunks = new Set<string>()
+
 /** A repo whose history the test scripts by hand: ancestry is a lookup, and a
  * sha that isn't listed answers null — "git couldn't say". */
 function fakeGit(head: string | null, ancestry: Record<string, boolean | null> = {}): LandedGit {
@@ -41,10 +45,15 @@ function fakeGit(head: string | null, ancestry: Record<string, boolean | null> =
 describe('maintainLanded', () => {
   it('stamps when the diff empties because HEAD advanced past the base', () => {
     const store = makeStore(tempRoot())
-    maintainLanded(store, true, fakeGit('base')) // work in flight: base recorded
+    maintainLanded(store, true, withHunks, fakeGit('base')) // work in flight: base recorded
     store.createThread(anchor, 'rename this', null)
 
-    const outcome = maintainLanded(store, false, fakeGit('landing', { 'base..landing': true }))
+    const outcome = maintainLanded(
+      store,
+      false,
+      noHunks,
+      fakeGit('landing', { 'base..landing': true }),
+    )
 
     expect(outcome).toBe('stamped')
     expect(store.get().landed).toMatchObject({ sha: 'landing', subject: 'subject of landing' })
@@ -55,31 +64,34 @@ describe('maintainLanded', () => {
 
   it('a stash empties the diff without moving HEAD — never stamps', () => {
     const store = makeStore(tempRoot())
-    maintainLanded(store, true, fakeGit('base'))
+    maintainLanded(store, true, withHunks, fakeGit('base'))
     store.createThread(anchor, 'about stashed work', null)
 
-    expect(maintainLanded(store, false, fakeGit('base'))).toBeNull()
+    expect(maintainLanded(store, false, noHunks, fakeGit('base'))).toBeNull()
     expect(store.get().landed).toBeUndefined()
   })
 
   it('an empty review has nothing to offer clearing — tracks the head instead', () => {
     const store = makeStore(tempRoot())
-    maintainLanded(store, true, fakeGit('base'))
+    maintainLanded(store, true, withHunks, fakeGit('base'))
 
-    expect(maintainLanded(store, false, fakeGit('landing', { 'base..landing': true }))).toBeNull()
+    expect(
+      maintainLanded(store, false, noHunks, fakeGit('landing', { 'base..landing': true })),
+    ).toBeNull()
     expect(store.get().landed).toBeUndefined()
     expect(store.get().seenHead).toBe('landing')
   })
 
   it('an amend rewrites the landing commit — the marker follows it in one pass', () => {
     const store = makeStore(tempRoot())
-    maintainLanded(store, true, fakeGit('base'))
+    maintainLanded(store, true, withHunks, fakeGit('base'))
     store.createThread(anchor, 'still relevant', null)
-    maintainLanded(store, false, fakeGit('landing', { 'base..landing': true }))
+    maintainLanded(store, false, noHunks, fakeGit('landing', { 'base..landing': true }))
 
     const outcome = maintainLanded(
       store,
       false,
+      noHunks,
       fakeGit('amended', { 'landing..amended': false, 'base..amended': true }),
     )
 
@@ -89,11 +101,16 @@ describe('maintainLanded', () => {
 
   it('a reset back to the base takes the work back — the marker goes, threads reattach', () => {
     const store = makeStore(tempRoot())
-    maintainLanded(store, true, fakeGit('base'))
+    maintainLanded(store, true, withHunks, fakeGit('base'))
     store.createThread(anchor, 'coming back', null)
-    maintainLanded(store, false, fakeGit('landing', { 'base..landing': true }))
+    maintainLanded(store, false, noHunks, fakeGit('landing', { 'base..landing': true }))
 
-    const outcome = maintainLanded(store, true, fakeGit('base', { 'landing..base': false }))
+    const outcome = maintainLanded(
+      store,
+      true,
+      withHunks,
+      fakeGit('base', { 'landing..base': false }),
+    )
 
     expect(outcome).toBe('cleared')
     expect(store.get().landed).toBeUndefined()
@@ -102,46 +119,131 @@ describe('maintainLanded', () => {
 
   it('ambiguity neither stamps nor clears: git that cannot answer changes nothing', () => {
     const store = makeStore(tempRoot())
-    maintainLanded(store, true, fakeGit('base'))
+    maintainLanded(store, true, withHunks, fakeGit('base'))
     store.createThread(anchor, 'thread', null)
 
     // isAncestor answers null (sha unknown, transient failure) — no stamp.
-    expect(maintainLanded(store, false, fakeGit('landing'))).toBeNull()
+    expect(maintainLanded(store, false, noHunks, fakeGit('landing'))).toBeNull()
     expect(store.get().landed).toBeUndefined()
 
     // And a marker already stamped survives the same ambiguity.
-    maintainLanded(store, false, fakeGit('landing', { 'base..landing': true }))
+    maintainLanded(store, false, noHunks, fakeGit('landing', { 'base..landing': true }))
     expect(store.get().landed?.sha).toBe('landing')
-    expect(maintainLanded(store, false, fakeGit('elsewhere'))).toBeNull()
+    expect(maintainLanded(store, false, noHunks, fakeGit('elsewhere'))).toBeNull()
     expect(store.get().landed?.sha).toBe('landing')
   })
 
   it('no HEAD (a repo with no commits) does nothing at all', () => {
     const store = makeStore(tempRoot())
     store.createThread(anchor, 'thread', null)
-    expect(maintainLanded(store, false, fakeGit(null))).toBeNull()
+    expect(maintainLanded(store, false, noHunks, fakeGit(null))).toBeNull()
     expect(store.get().seenHead).toBeUndefined()
   })
 
   it('new work over an unanswered offer keeps the marker and re-bases seenHead', () => {
     const store = makeStore(tempRoot())
-    maintainLanded(store, true, fakeGit('base'))
+    maintainLanded(store, true, withHunks, fakeGit('base'))
     store.createThread(anchor, 'old round', null)
-    maintainLanded(store, false, fakeGit('landing', { 'base..landing': true }))
+    maintainLanded(store, false, noHunks, fakeGit('landing', { 'base..landing': true }))
 
     // The agent starts the next round before the reviewer clears.
-    expect(maintainLanded(store, true, fakeGit('landing', {}))).toBeNull()
+    expect(maintainLanded(store, true, new Set(['h2']), fakeGit('landing', {}))).toBeNull()
     expect(store.get().landed?.sha).toBe('landing')
     expect(store.get().seenHead).toBe('landing')
   })
 
   it('a lastFinish alone (all threads resolved away) still deserves the offer', () => {
     const store = makeStore(tempRoot())
-    maintainLanded(store, true, fakeGit('base'))
+    maintainLanded(store, true, withHunks, fakeGit('base'))
     store.recordFinish(['h1'], { viewedHunks: 1, totalHunks: 1, skippedFiles: [] })
 
-    const outcome = maintainLanded(store, false, fakeGit('landing', { 'base..landing': true }))
+    const outcome = maintainLanded(
+      store,
+      false,
+      noHunks,
+      fakeGit('landing', { 'base..landing': true }),
+    )
     expect(outcome).toBe('stamped')
+  })
+
+  it('a commit and a new round both made while no server ran — stamps over the new diff', () => {
+    const store = makeStore(tempRoot())
+    maintainLanded(store, true, withHunks, fakeGit('base'))
+    store.createThread(anchor, 'old round', null)
+
+    // Startup: the diff already carries the next feature, but every hunk the
+    // review pointed at is gone and HEAD advanced past the recorded base.
+    const outcome = maintainLanded(
+      store,
+      true,
+      new Set(['h2']),
+      fakeGit('landing', { 'base..landing': true }),
+    )
+
+    expect(outcome).toBe('stamped')
+    expect(store.get().landed?.sha).toBe('landing')
+    // The diff has files, so the base moves on with it — the offer is stamped,
+    // there is nothing left to freeze for.
+    expect(store.get().seenHead).toBe('landing')
+  })
+
+  it('an unrelated commit leaves the reviewed hunks in the diff — no stamp', () => {
+    const store = makeStore(tempRoot())
+    maintainLanded(store, true, withHunks, fakeGit('base'))
+    store.createThread(anchor, 'still under review', null)
+
+    const outcome = maintainLanded(
+      store,
+      true,
+      new Set(['h1', 'h2']),
+      fakeGit('lockfile', { 'base..lockfile': true }),
+    )
+
+    expect(outcome).toBeNull()
+    expect(store.get().landed).toBeUndefined()
+  })
+
+  it('a partial commit leaves some reviewed hunks outstanding — no stamp', () => {
+    const store = makeStore(tempRoot())
+    maintainLanded(store, true, new Set(['h1', 'h2']), fakeGit('base'))
+    store.createThread(anchor, 'one of two', null)
+    store.recordFinish(['h1', 'h2'], { viewedHunks: 2, totalHunks: 2, skippedFiles: [] })
+
+    const outcome = maintainLanded(
+      store,
+      true,
+      new Set(['h2']),
+      fakeGit('half', { 'base..half': true }),
+    )
+
+    expect(outcome).toBeNull()
+    expect(store.get().landed).toBeUndefined()
+  })
+
+  it('a review that never anchored to a hunk cannot testify over a non-empty diff', () => {
+    const store = makeStore(tempRoot())
+    maintainLanded(store, true, withHunks, fakeGit('base'))
+    store.createThread({ kind: 'changeset' }, 'the guide', null, undefined, 'agent')
+
+    const outcome = maintainLanded(
+      store,
+      true,
+      new Set(['h2']),
+      fakeGit('landing', { 'base..landing': true }),
+    )
+
+    expect(outcome).toBeNull()
+    expect(store.get().landed).toBeUndefined()
+  })
+
+  it("the unwitnessed path still refuses git's silence", () => {
+    const store = makeStore(tempRoot())
+    maintainLanded(store, true, withHunks, fakeGit('base'))
+    store.createThread(anchor, 'old round', null)
+
+    // Hunks vanished and HEAD moved, but ancestry answers null — no stamp.
+    expect(maintainLanded(store, true, new Set(['h2']), fakeGit('landing'))).toBeNull()
+    expect(store.get().landed).toBeUndefined()
   })
 
   it('against a real repo: commit stamps, and the subject rides along', () => {
@@ -164,18 +266,18 @@ describe('maintainLanded', () => {
     }
 
     writeFileSync(join(root, 'app.ts'), 'const a = 2\n')
-    maintainLanded(store, true, realGit)
+    maintainLanded(store, true, withHunks, realGit)
     store.createThread(anchor, 'why 2?', null)
 
     git('add', '-A')
     git('commit', '-m', 'the work lands')
-    expect(maintainLanded(store, false, realGit)).toBe('stamped')
+    expect(maintainLanded(store, false, noHunks, realGit)).toBe('stamped')
     expect(store.get().landed?.subject).toBe('the work lands')
     expect(store.get().landed?.sha).toBe(getHeadSha(root))
 
     // git reset --soft brings the exact hunks back: marker drops, threads intact.
     git('reset', '--soft', 'HEAD~1')
-    expect(maintainLanded(store, true, realGit)).toBe('cleared')
+    expect(maintainLanded(store, true, withHunks, realGit)).toBe('cleared')
     expect(store.get().landed).toBeUndefined()
     expect(store.get().threads).toHaveLength(1)
   })

--- a/src/server/landed.ts
+++ b/src/server/landed.ts
@@ -1,3 +1,4 @@
+import type { ReviewState } from '../shared/review.js'
 import type { ReviewStore } from './review.js'
 
 /** The git questions landed-detection asks, injectable so the logic is testable
@@ -17,6 +18,15 @@ export interface LandedGit {
  *   committed. Stamp `landed` — the UI's cue to offer a fresh start. A stash
  *   empties the diff without moving HEAD, so it never stamps; a branch switch
  *   is rescoped to its own review before this runs.
+ * - The commit can also go unwitnessed: it lands and the next round starts
+ *   while no server watches, so no recompute ever sees the empty diff. The
+ *   evidence survives anyway — HEAD advanced past `seenHead` AND every hunk
+ *   the review pointed at (thread anchors, the last finish) is gone from the
+ *   current changeset. Both together stamp even over a non-empty diff; either
+ *   alone does not (an unrelated commit leaves the reviewed hunks in place, an
+ *   agent rewriting every hunk between recomputes leaves HEAD at `seenHead`).
+ *   A review that never anchored to a hunk has no such evidence and waits for
+ *   the witnessed path.
  * - A landed commit that left HEAD's history (reset, or an amend rewriting it)
  *   drops the marker — and an amend re-stamps in the same pass, because
  *   `seenHead` is still the pre-landing base and IS an ancestor of the
@@ -32,6 +42,7 @@ export interface LandedGit {
 export function maintainLanded(
   review: ReviewStore,
   hasFiles: boolean,
+  currentHunkIds: ReadonlySet<string>,
   git: LandedGit,
 ): 'stamped' | 'cleared' | null {
   const head = git.head()
@@ -50,7 +61,7 @@ export function maintainLanded(
 
   if (
     !review.get().landed &&
-    !hasFiles &&
+    (!hasFiles || reviewedHunksAllLanded(state, currentHunkIds)) &&
     !reviewEmpty &&
     state.seenHead !== undefined &&
     state.seenHead !== head &&
@@ -63,4 +74,19 @@ export function maintainLanded(
 
   if (hasFiles || reviewEmpty) review.noteHead(head)
   return outcome
+}
+
+/** The unwitnessed-landing evidence: the review pointed at hunks, and none of
+ * them survive in the current changeset. Vacuous truth deliberately fails —
+ * a review of only file- and changeset-anchored threads names no hunks, so it
+ * cannot testify that they landed. */
+function reviewedHunksAllLanded(state: ReviewState, currentHunkIds: ReadonlySet<string>): boolean {
+  const referenced = new Set<string>()
+  for (const thread of state.threads) {
+    if (thread.anchor.kind === 'hunk') referenced.add(thread.anchor.hunkId)
+  }
+  for (const id of state.lastFinish?.hunkIds ?? []) referenced.add(id)
+  if (referenced.size === 0) return false
+  for (const id of referenced) if (currentHunkIds.has(id)) return false
+  return true
 }

--- a/src/server/prompt.test.ts
+++ b/src/server/prompt.test.ts
@@ -6,6 +6,7 @@ import type { ReviewThread } from '../shared/review.js'
 import type { Changeset } from '../shared/types.js'
 import {
   ACK_NEXT_STEP,
+  buildClearedPrompt,
   buildCoalescedPrompt,
   buildFinishPrompt,
   buildInstallSkill,
@@ -419,6 +420,13 @@ describe('the poll envelope (next_step per payload kind)', () => {
     expect(empty).not.toMatch(/act on each thread/i)
   })
 
+  it('a cleared payload points at the guide, then back to the poll', () => {
+    const step = nextStepFor('cleared', 0)
+    expect(step).toMatch(/guide/i)
+    expect(step).toMatch(/keep listening/i)
+    expect(step).not.toMatch(/act on each thread/i)
+  })
+
   it('every ack teaches the next step; end pairs the prohibition with its alternative', () => {
     expect(ACK_NEXT_STEP.reply).toContain('poll')
     expect(ACK_NEXT_STEP.comment).toMatch(/replies to take it up, or resolves it/i)
@@ -481,6 +489,28 @@ describe('the open-time guide nudge', () => {
     expect(guideNudge(false)).toContain(CLI_COMMANDS.guide)
     // The guide anchors to the changeset, so the command must not offer a file.
     expect(guideNudge(false)).not.toContain('[<file>]')
+  })
+})
+
+describe('the cleared payload (reviewer started the review over)', () => {
+  it('says what happened, owes nothing, and restates the guide doctrine', () => {
+    const prompt = buildClearedPrompt({ repo, changeset: changeset() })
+    expect(prompt).toContain('cleared the review')
+    expect(prompt).toContain('no feedback to act on')
+    // The same doctrine as the open-time nudge: agent judgment, no pre-review.
+    expect(prompt).toContain('skip when the diff explains itself')
+    expect(prompt).toContain('never pre-review')
+    expect(prompt).toContain(CLI_COMMANDS.guide)
+    expect(prompt).not.toContain('[<file>]')
+    // It frames the fresh round the reviewer is now looking at.
+    expect(prompt).toContain('The changeset under review')
+  })
+
+  it('stands alone without a changeset, and always routes back to the poll', () => {
+    const prompt = buildClearedPrompt({ repo, changeset: null })
+    expect(prompt).toContain('cleared the review')
+    expect(prompt).toContain(CLI_COMMANDS.poll)
+    expect(prompt).not.toContain('The changeset under review')
   })
 })
 

--- a/src/server/prompt.ts
+++ b/src/server/prompt.ts
@@ -83,7 +83,10 @@ export const JOIN_PROMPT =
   `join the diffo review: run \`${CLI_COMMANDS.poll}\` (${POLL_STANCE}) ` +
   'and follow the JSON payload it prints — each payload carries its own instructions'
 
-export function nextStepFor(kind: 'threads' | 'finish', actionable: number): string {
+export function nextStepFor(kind: 'threads' | 'finish' | 'cleared', actionable: number): string {
+  if (kind === 'cleared') {
+    return `Post the guide if this changeset warrants one, then run \`${CLI_COMMANDS.poll}\` again to keep listening (${POLL_STANCE}).`
+  }
   if (kind === 'finish' && actionable === 0) {
     return `Nothing to act on — run \`${CLI_COMMANDS.poll}\` again to keep listening (${POLL_STANCE}); the reviewer may follow up.`
   }
@@ -333,6 +336,24 @@ export function buildCoalescedPrompt(threads: ReviewThread[], ctx: PromptContext
     ...threads.map((t, i) => `${threadBlock(t, i)}\n`),
     ...(siblings ? [siblings, ''] : []),
     replyProtocol(threads),
+    '',
+  ].join('\n')
+}
+
+/**
+ * The reviewer started the review over — the previous round landed, and its
+ * threads and guide were cleared. Nothing to act on; the one thing owed is
+ * orientation for the fresh round, so this restates the guide doctrine the way
+ * the open-time nudge does (payloads must stand alone — see POLL_STANCE).
+ */
+export function buildClearedPrompt(ctx: PromptContext): string {
+  return [
+    `The reviewer cleared the review in \`${ctx.repo.name}\` (branch \`${ctx.repo.branch}\`): the previous round landed, and its threads and guide are gone. What the reviewer sees now is a fresh round.`,
+    '',
+    ...(ctx.changeset ? [specLine(ctx.changeset), ''] : []),
+    `There is no feedback to act on. But the fresh round has no guide — if this changeset needs one (${GUIDE.when}): post it — one comment on the whole changeset: ${GUIDE.what}: \`${CLI_COMMANDS.guide}\` (no file, so it anchors to the changeset). ${GUIDE.stance}.`,
+    '',
+    `Then run \`${CLI_COMMANDS.poll}\` again to keep listening (${POLL_STANCE}).`,
     '',
   ].join('\n')
 }

--- a/src/server/review-api.test.ts
+++ b/src/server/review-api.test.ts
@@ -496,13 +496,17 @@ describe('review API', () => {
     const res = await app.request('/api/review/threads', { method: 'DELETE' })
     expect(res.status).toBe(200)
     expect(await res.json()).toEqual({ removed: 2 })
-    expect(queue.take()).toBeNull()
+    // The pending thread deliveries are gone; what remains is the one heads-up
+    // that the slate was cleared (the changeset on screen still has files).
+    expect(queue.take()).toEqual({ kind: 'cleared' })
 
     const list = (await (await app.request('/api/review')).json()) as { threads: ReviewThread[] }
     expect(list.threads).toEqual([])
+    // A reset of an already-empty review owes nothing — no second heads-up.
     const again = await app.request('/api/review/threads', { method: 'DELETE' })
     expect(again.status).toBe(200)
     expect(await again.json()).toEqual({ removed: 0 })
+    expect(queue.take()).toEqual({ kind: 'cleared' })
   })
 
   it('DELETE on the collection is a full reset: lastFinish and the landed marker go too', async () => {
@@ -571,6 +575,34 @@ describe('the pull loop', () => {
 
     expect(queue.take()).toBeNull()
     expect(queue.presence()).toBe('working')
+  })
+
+  it('a reset wakes a waiting poll with the cleared heads-up — a fresh guide is owed', async () => {
+    const { app, queue } = setup()
+    const created = await post(app, '/api/review/threads', {
+      anchor: { kind: 'changeset' },
+      text: 'the old guide',
+    })
+    await post(app, `/api/review/threads/${((await created.json()) as ReviewThread).id}/send`)
+    // Drain the send: the agent is mid-round when the reviewer starts over.
+    await pollResult(await app.request('/api/agent/poll', { headers: { 'x-diffo-agent': 'cli' } }))
+
+    const poll = Promise.resolve(
+      app.request('/api/agent/poll', { headers: { 'x-diffo-agent': 'cli' } }),
+    ).then(pollResult)
+    await tick()
+    await app.request('/api/review/threads', { method: 'DELETE' })
+
+    const payload = await poll
+    expect(payload.status).toBe('feedback')
+    expect(payload.kind).toBe('cleared')
+    expect(payload.threadIds).toEqual([])
+    expect(payload.prompt).toContain('cleared the review')
+    expect(payload.prompt).toContain('post it — one comment on the whole changeset')
+    expect(payload.prompt).toContain('npx -y @diffohq/diffo comment')
+    expect(payload.next_step).toContain('diffo poll')
+    // Consumed: the next poll owes nothing.
+    expect(queue.take()).toBeNull()
   })
 
   it('a send resolves a WAITING poll immediately and reports delivered', async () => {


### PR DESCRIPTION
A commit made between server runs never shows the empty-diff moment the landed marker keyed on: startup saw the next round's diff, advanced seenHead, and the previous round's threads and guide sat under the new changeset forever with no fresh-start offer.

Two changes close the gap:

- maintainLanded gains an unwitnessed path: HEAD advanced past seenHead AND every hunk the review referenced (thread anchors, the last finish) is gone from the current changeset stamps the marker even over a non-empty diff. Either signal alone still never stamps, and git ambiguity still never stamps.
- Start fresh now tells the polling agent: the reset endpoint queues a 'cleared' delivery (outranked by real feedback, one heads-up no matter how many resets) whose payload restates the guide doctrine, so the fresh round gets a new guide instead of silently running without one.