### PR TITLE
fix: make the typed file filter narrow the pane, not just the rail

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -241,6 +241,7 @@ function Review() {
   const [inviteOpen, setInviteOpen] = useState(false)
   const [theme, setTheme] = useTheme()
   const [panel, setPanel] = useState<PanelTab>('files')
+  const [searchFocusTick, setSearchFocusTick] = useState(0)
 
   const agentAttached = presence !== 'waiting'
 
@@ -795,7 +796,13 @@ function Review() {
       } else if (action === 'toggle-nav') {
         toggleNav()
       } else if (action === 'focus-search') {
-        document.querySelector<HTMLInputElement>('.nav-search')?.focus()
+        // The box lives on the rail's Files tab — summon both, so `/` works with
+        // the rail collapsed or the Threads tab up. The tick lets Nav focus its
+        // own input after the same commit that reveals it; a display:none input
+        // swallows focus(), so focusing from here would be a race.
+        setPanel('files')
+        setNavHidden(false)
+        setSearchFocusTick((t) => t + 1)
       } else if (action === 'next-unreviewed') {
         nextUnreviewed()
       } else if (action === 'shortcuts') {
@@ -909,6 +916,9 @@ function Review() {
               threads={fileThreads}
               attention={fileAttention}
               changed={sinceLastReview.changed}
+              query={filter.query}
+              onQuery={filter.setQuery}
+              focusTick={searchFocusTick}
               hideReviewed={filter.hideReviewed}
               onHideReviewed={filter.setHideReviewed}
               hideTests={filter.hideTests}
@@ -975,6 +985,9 @@ function Review() {
             onToggleNav: toggleNav,
             left: fileProgress.total - fileProgress.viewed,
             total: fileProgress.total,
+            query: filter.query,
+            onClearQuery: () => filter.setQuery(''),
+            hiddenQuery: filter.hiddenQuery,
             hideReviewed: filter.hideReviewed,
             onHideReviewed: filter.setHideReviewed,
             hideTests: filter.hideTests,

--- a/src/ui/components/Nav.test.tsx
+++ b/src/ui/components/Nav.test.tsx
@@ -103,6 +103,20 @@ describe('Nav', () => {
     expect(screen.queryByLabelText('Clear filter')).toBeNull()
   })
 
+  it('when the app drives the filter, keystrokes report up and the value is obeyed', () => {
+    const onQuery = vi.fn()
+    const { rerender } = render(<Nav files={FILES} query="git" onQuery={onQuery} />)
+    expect(names()).toEqual(['src/server', 'git.ts'])
+    fireEvent.change(screen.getByLabelText('Filter files'), { target: { value: 'app' } })
+    expect(onQuery).toHaveBeenCalledWith('app')
+    // The box did not move on its own — the app owns the value.
+    expect((screen.getByLabelText('Filter files') as HTMLInputElement).value).toBe('git')
+    rerender(<Nav files={FILES} query="app" onQuery={onQuery} />)
+    expect(names()).toEqual(['src/ui', 'App.tsx'])
+    fireEvent.click(screen.getByLabelText('Clear filter'))
+    expect(onQuery).toHaveBeenCalledWith('')
+  })
+
   it('a file click hands the pick to the app, which expands the file first', () => {
     const onPickFile = vi.fn()
     render(<Nav files={FILES} onPickFile={onPickFile} />)

--- a/src/ui/components/Nav.tsx
+++ b/src/ui/components/Nav.tsx
@@ -1,4 +1,4 @@
-import { type ReactElement, useCallback, useMemo, useRef, useState } from 'react'
+import { type ReactElement, useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import type { ReviewThread } from '../../shared/review.js'
 import type { FileChange, FileStatus } from '../../shared/types.js'
 import { isFileViewed } from '../fileMarks.js'
@@ -213,6 +213,9 @@ export function Nav({
   threads,
   attention,
   changed,
+  query: sharedQuery,
+  onQuery,
+  focusTick = 0,
   hideReviewed = false,
   onHideReviewed,
   hideTests = false,
@@ -231,6 +234,14 @@ export function Nav({
   threads?: Map<string, ReviewThread[]>
   attention?: Map<string, ThreadItem[]>
   changed?: ReadonlySet<string>
+  /** The typed filter is review-wide state, not the rail's: the pane narrows by the
+   * same word (`useReviewFilter`), so the tree stays a map of what the pane shows. */
+  query?: string
+  onQuery?: (q: string) => void
+  /** Bumped by the app when `/` is pressed. Focusing is Nav's own job: the press may
+   * also be what reveals the rail, and only an effect here runs after that commit —
+   * a display:none input swallows focus(). */
+  focusTick?: number
   hideReviewed?: boolean
   onHideReviewed?: (on: boolean) => void
   hideTests?: boolean
@@ -238,9 +249,16 @@ export function Nav({
   onlyChanged?: boolean
   onOnlyChanged?: (on: boolean) => void
 }) {
-  const [query, setQuery] = useState('')
+  // Uncontrolled fallback so the rail still filters when no owner drives it.
+  const [localQuery, setLocalQuery] = useState('')
+  const query = sharedQuery ?? localQuery
+  const setQuery = onQuery ?? setLocalQuery
   const [shut, setShut] = useState<ReadonlySet<string>>(new Set())
   const searchRef = useRef<HTMLInputElement>(null)
+
+  useEffect(() => {
+    if (focusTick > 0) searchRef.current?.focus()
+  }, [focusTick])
 
   const isDone = useCallback((file: FileChange) => isFileViewed(file, viewed), [viewed])
 

--- a/src/ui/components/PaneBar.test.tsx
+++ b/src/ui/components/PaneBar.test.tsx
@@ -58,3 +58,21 @@ describe('the file-list toggle', () => {
     )
   })
 })
+
+describe('the typed-filter chip', () => {
+  it('echoes the rail’s word, and the whole chip is its own clear', () => {
+    const onClearQuery = vi.fn()
+    render(bar({ query: 'auth', onClearQuery }))
+    const chip = screen.getByLabelText('Clear the file filter “auth”')
+    expect(chip.textContent).toContain('auth')
+    fireEvent.click(chip)
+    expect(onClearQuery).toHaveBeenCalled()
+  })
+
+  it('is not there with nothing typed — whitespace included', () => {
+    const { container, rerender } = render(bar({ query: '', onClearQuery: () => {} }))
+    expect(container.querySelector('.pane-q')).toBeNull()
+    rerender(bar({ query: '   ', onClearQuery: () => {} }))
+    expect(container.querySelector('.pane-q')).toBeNull()
+  })
+})

--- a/src/ui/components/PaneBar.tsx
+++ b/src/ui/components/PaneBar.tsx
@@ -6,6 +6,8 @@ export function PaneBar({
   onToggleNav,
   left,
   total,
+  query = '',
+  onClearQuery,
   hideReviewed,
   onHideReviewed,
   hideTests,
@@ -24,6 +26,10 @@ export function PaneBar({
   onToggleNav?: () => void
   left: number
   total: number
+  /** The rail's typed filter. The pane obeys it, so the bar must say so — with the
+   * rail collapsed this chip is the only trace of why files are missing. */
+  query?: string
+  onClearQuery?: () => void
   hideReviewed: boolean
   onHideReviewed: (on: boolean) => void
   hideTests: boolean
@@ -41,6 +47,7 @@ export function PaneBar({
   const done = total - left
   const showTests = testCount > 0 || hideTests
   const showChanged = changedCount > 0 || onlyChanged
+  const trimmedQuery = query.trim()
   return (
     <div className="pane-bar">
       {onToggleNav && (
@@ -75,6 +82,19 @@ export function PaneBar({
           </button>
           <span className="pane-sep" />
         </>
+      )}
+      {trimmedQuery !== '' && onClearQuery && (
+        <button
+          type="button"
+          className="pane-q"
+          title={`Showing only files matching “${trimmedQuery}” — click to clear`}
+          aria-label={`Clear the file filter “${trimmedQuery}”`}
+          onClick={onClearQuery}
+        >
+          <Icon name="search" size="sm" />
+          <span className="pane-q-word">{trimmedQuery}</span>
+          <Icon name="x" size="sm" />
+        </button>
       )}
       {showChanged && (
         <Switch

--- a/src/ui/components/ReadingPane.test.tsx
+++ b/src/ui/components/ReadingPane.test.tsx
@@ -345,6 +345,9 @@ describe('ReadingPane — the pane bar', () => {
       onlyChanged: false,
       onOnlyChanged: () => {},
       changedCount: 0,
+      query: '',
+      onClearQuery: () => {},
+      hiddenQuery: 0,
       hiddenTests: 0,
       hiddenReviewed: 0,
       hiddenUnchanged: 0,
@@ -453,6 +456,35 @@ describe('ReadingPane — the pane bar', () => {
   it('singularises one hidden test', () => {
     render(<ReadingPane files={[FILES[0]!]} controls={controls({ hiddenTests: 1 })} />)
     expect(screen.getByText(/1 test /)).toBeTruthy()
+  })
+
+  it('names the typed word first among the reasons files are missing', () => {
+    render(
+      <ReadingPane
+        files={[FILES[0]!]}
+        controls={controls({ query: 'auth', hiddenQuery: 3, hiddenTests: 4 })}
+      />,
+    )
+    expect(screen.getByText(/3 not matching “auth”, 4 tests hidden/)).toBeTruthy()
+  })
+
+  it('blames the word, not the switches, when the word alone emptied the pane', () => {
+    render(
+      <ReadingPane files={[]} controls={controls({ left: 12, query: 'zzz', hiddenQuery: 30 })} />,
+    )
+    expect(screen.getByText('None of them match “zzz”.')).toBeTruthy()
+  })
+
+  it('blames both when the word and the switches each hid something', () => {
+    render(
+      <ReadingPane
+        files={[]}
+        controls={controls({ left: 12, query: 'zzz', hiddenQuery: 20, hiddenReviewed: 10 })}
+      />,
+    )
+    expect(
+      screen.getByText("They're hidden by “zzz” and the switches on the bar above."),
+    ).toBeTruthy()
   })
 
   it('ends on the payoff, not on the clean-tree empty state', () => {

--- a/src/ui/components/ReadingPane.tsx
+++ b/src/ui/components/ReadingPane.tsx
@@ -35,6 +35,9 @@ export interface PaneControls {
   onToggleNav?: () => void
   left: number
   total: number
+  query: string
+  onClearQuery: () => void
+  hiddenQuery: number
   hideReviewed: boolean
   onHideReviewed: (on: boolean) => void
   hideTests: boolean
@@ -819,7 +822,8 @@ export function ReadingPane({
   const hiddenCount =
     (controls?.hiddenTests ?? 0) +
     (controls?.hiddenReviewed ?? 0) +
-    (controls?.hiddenUnchanged ?? 0)
+    (controls?.hiddenUnchanged ?? 0) +
+    (controls?.hiddenQuery ?? 0)
 
   const done = controls && (
     <ReviewDone
@@ -857,7 +861,13 @@ export function ReadingPane({
       <h2>
         {controls.left} {controls.left === 1 ? 'file' : 'files'} still to review
       </h2>
-      <p>They're hidden by the switches on the bar above.</p>
+      <p>
+        {controls.hiddenQuery === 0
+          ? "They're hidden by the switches on the bar above."
+          : controls.hiddenTests + controls.hiddenReviewed + controls.hiddenUnchanged === 0
+            ? `None of them match “${controls.query.trim()}”.`
+            : `They're hidden by “${controls.query.trim()}” and the switches on the bar above.`}
+      </p>
       <div className="empty-acts">
         <button type="button" className="btn btn-ghost" onClick={controls.onShowAll}>
           Show all files
@@ -935,6 +945,9 @@ export function ReadingPane({
           <span className="pane-hidden-said">
             <Icon name="eye-off" size="sm" />
             {[
+              controls.hiddenQuery > 0
+                ? `${controls.hiddenQuery} not matching “${controls.query.trim()}”`
+                : null,
               controls.hiddenUnchanged > 0 ? `${controls.hiddenUnchanged} unchanged` : null,
               controls.hiddenTests > 0
                 ? `${controls.hiddenTests} test${controls.hiddenTests === 1 ? '' : 's'}`
@@ -961,6 +974,8 @@ export function ReadingPane({
           onToggleNav={controls.onToggleNav}
           left={controls.left}
           total={controls.total}
+          query={controls.query}
+          onClearQuery={controls.onClearQuery}
           hideReviewed={controls.hideReviewed}
           onHideReviewed={controls.onHideReviewed}
           hideTests={controls.hideTests}

--- a/src/ui/reviewFilter.test.ts
+++ b/src/ui/reviewFilter.test.ts
@@ -30,6 +30,7 @@ describe('splitFiles', () => {
   const files = [file('src/a.ts'), file('src/a.test.ts'), file('src/b.ts')]
   const done = (paths: string[]) => (f: FileChange) => paths.includes(f.path)
   const opts = (over: Partial<Parameters<typeof splitFiles>[1]> = {}) => ({
+    query: '',
     hideReviewed: false,
     hideTests: false,
     onlyChanged: false,
@@ -146,6 +147,35 @@ describe('splitFiles', () => {
       opts({ onlyChanged: true, changed: NONE, pinned: new Set(['src/a.ts']) }),
     )
     expect(paths(split.visible)).toEqual(['src/a.ts'])
+  })
+
+  it('the typed word narrows by path, case-insensitively, and counts what it drops', () => {
+    const split = splitFiles(files, opts({ query: 'B.TS' }))
+    expect(paths(split.visible)).toEqual(['src/b.ts'])
+    expect(split.hiddenQuery).toBe(2)
+  })
+
+  it('an all-space query filters nothing', () => {
+    const split = splitFiles(files, opts({ query: '   ' }))
+    expect(paths(split.visible)).toEqual(['src/a.ts', 'src/a.test.ts', 'src/b.ts'])
+    expect(split.hiddenQuery).toBe(0)
+  })
+
+  it('a file the word drops is claimed by the word, whatever else would hide it', () => {
+    const split = splitFiles(
+      files,
+      opts({ query: 'b.ts', hideTests: true, hideReviewed: true, isDone: done(['src/a.ts']) }),
+    )
+    expect(paths(split.visible)).toEqual(['src/b.ts'])
+    expect(split.hiddenQuery).toBe(2)
+    expect(split.hiddenTests).toBe(0)
+    expect(split.hiddenReviewed).toBe(0)
+  })
+
+  it('a pin outranks the typed word — a jump must land even mid-search', () => {
+    const split = splitFiles(files, opts({ query: 'zzz', pinned: new Set(['src/a.ts']) }))
+    expect(paths(split.visible)).toEqual(['src/a.ts'])
+    expect(split.hiddenQuery).toBe(2)
   })
 })
 

--- a/src/ui/reviewFilter.ts
+++ b/src/ui/reviewFilter.ts
@@ -25,6 +25,7 @@ export interface FilterSplit {
   hiddenTests: number
   hiddenReviewed: number
   hiddenUnchanged: number
+  hiddenQuery: number
 }
 
 /**
@@ -33,7 +34,8 @@ export interface FilterSplit {
  * Completion is measured against **scope** — what you asked to see — because
  * `Hide tests` hides files rather than reading them. The excluded files are named
  * instead of quietly counted as done. `Hide reviewed` is not a scope: those files
- * are read, which is why they left.
+ * are read, which is why they left. The typed query is not a scope either — a word
+ * in a search box is a look-around, and must never make a review count as finished.
  */
 export interface ReviewScope {
   left: number
@@ -83,18 +85,21 @@ export function reviewScope(
 }
 
 /**
- * Apply all three filters, counting what each one took.
+ * Apply all the filters, counting what each one took.
  *
  * `pinned` wins over all of them, and that is the escape hatch: a rail click, a `J`
  * or a thread jump names a path here and it renders regardless of what is switched
  * on. A tick never pins — the filter keeps its word, and the file goes.
  *
- * Tests are counted before reviewed so a reviewed test file reports as one hidden
- * test rather than being claimed twice.
+ * The query is answered first: a typed word is the most deliberate narrowing on the
+ * bar, so a file it drops is reported as "doesn't match", whatever else would also
+ * have hidden it. Tests are counted before reviewed so a reviewed test file reports
+ * as one hidden test rather than being claimed twice.
  */
 export function splitFiles(
   files: readonly FileChange[],
   opts: {
+    query: string
     hideReviewed: boolean
     hideTests: boolean
     onlyChanged: boolean
@@ -104,16 +109,23 @@ export function splitFiles(
   },
 ): FilterSplit {
   const visible: FileChange[] = []
+  const q = opts.query.trim().toLowerCase()
   let hiddenTests = 0
   let hiddenReviewed = 0
   let hiddenUnchanged = 0
+  let hiddenQuery = 0
   for (const file of files) {
     if (opts.pinned.has(file.path)) {
       visible.push(file)
       continue
     }
-    // The narrowing is answered first, and wins: "only what came back" is a scope
-    // rather than a hide, so everything outside it is out for that reason.
+    if (q !== '' && !file.path.toLowerCase().includes(q)) {
+      hiddenQuery++
+      continue
+    }
+    // The narrowing is answered next, and wins over the hides: "only what came
+    // back" is a scope rather than a hide, so everything outside it is out for
+    // that reason.
     if (opts.onlyChanged && !opts.changed.has(file.path)) {
       hiddenUnchanged++
       continue
@@ -128,10 +140,12 @@ export function splitFiles(
     }
     visible.push(file)
   }
-  return { visible, hiddenTests, hiddenReviewed, hiddenUnchanged }
+  return { visible, hiddenTests, hiddenReviewed, hiddenUnchanged, hiddenQuery }
 }
 
 export interface ReviewFilter {
+  query: string
+  setQuery: (q: string) => void
   hideReviewed: boolean
   hideTests: boolean
   setHideReviewed: (on: boolean) => void
@@ -142,6 +156,7 @@ export interface ReviewFilter {
   hiddenTests: number
   hiddenReviewed: number
   hiddenUnchanged: number
+  hiddenQuery: number
   testCount: number
   changedCount: number
   scope: ReviewScope
@@ -163,6 +178,17 @@ export function useReviewFilter(
   )
   const [testsChoice, setTestsChoice] = useState<boolean | null>(() => storedChoice(KEY_TESTS))
   const [pinned, setPinned] = useState<ReadonlySet<string>>(new Set())
+  // The typed filter is one shared narrowing: the rail's box edits it and the pane
+  // obeys it, so the tree is always a map of what the pane renders. Deliberately
+  // transient — a word you typed for this look-around must not survive a reload
+  // the way the switches do.
+  const [query, setQueryState] = useState('')
+
+  const setQuery = useCallback((q: string) => {
+    setQueryState(q)
+    // Stale pins would defeat a fresh narrowing — same reset the switches do.
+    setPinned((prev) => (prev.size === 0 ? prev : new Set()))
+  }, [])
 
   const hideReviewed = reviewedChoice ?? files.length > AUTO_HIDE_ABOVE
   const hideTests = testsChoice ?? false
@@ -198,12 +224,14 @@ export function useReviewFilter(
     setReviewedChoice(false)
     setTestsChoice(false)
     setPinned(new Set())
+    setQueryState('')
     setSince(false)
   }, [setSince])
 
   const split = useMemo(
     () =>
       splitFiles(files, {
+        query,
         hideReviewed,
         hideTests,
         onlyChanged: since.on,
@@ -211,7 +239,7 @@ export function useReviewFilter(
         pinned,
         isDone,
       }),
-    [files, hideReviewed, hideTests, since.on, since.changed, pinned, isDone],
+    [files, query, hideReviewed, hideTests, since.on, since.changed, pinned, isDone],
   )
 
   const testCount = useMemo(() => files.filter((f) => isTestFile(f.path)).length, [files])
@@ -229,6 +257,8 @@ export function useReviewFilter(
   )
 
   return {
+    query,
+    setQuery,
     hideReviewed,
     hideTests,
     setHideReviewed,
@@ -239,6 +269,7 @@ export function useReviewFilter(
     hiddenTests: split.hiddenTests,
     hiddenReviewed: split.hiddenReviewed,
     hiddenUnchanged: split.hiddenUnchanged,
+    hiddenQuery: split.hiddenQuery,
     testCount,
     changedCount: since.changed.size,
     scope,

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -1394,6 +1394,49 @@ body {
   white-space: nowrap;
 }
 
+/* The rail's typed filter, echoed on the bar: with the rail collapsed this chip is
+   the only trace of why files are missing, and the whole chip is its own clear. */
+.pane-q {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--s-2);
+  flex-shrink: 1;
+  min-width: 0;
+  padding: 3px var(--s-3);
+  border: none;
+  border-radius: var(--r-pill);
+  background: var(--fill);
+  font: inherit;
+  font-size: var(--t-12);
+  color: var(--ink);
+  cursor: pointer;
+  transition:
+    color var(--dur) var(--ease-out),
+    background var(--dur) var(--ease-out);
+}
+
+.pane-q:hover {
+  background: var(--fill-2);
+}
+
+.pane-q:focus-visible {
+  outline: 2px solid var(--acc);
+  outline-offset: 1px;
+}
+
+.pane-q .icon {
+  flex: none;
+  color: var(--ink-3);
+}
+
+.pane-q-word {
+  overflow: hidden;
+  max-width: 14ch;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--mono);
+}
+
 .pane-sw {
   display: inline-flex;
   align-items: center;


### PR DESCRIPTION
The Filter files box was Nav-local state: the tree narrowed while the reading pane kept rendering everything — the two surfaces disagreed, and with the rail collapsed there was no trace a filter was active at all.

The query now lives in useReviewFilter beside the switches, so both surfaces obey one narrowing. splitFiles answers it first and counts what it drops; a pin still outranks it, so thread jumps land mid-search; Show all files clears it along with everything else. It stays out of reviewScope — a typed word must never make a review count as finished — and is deliberately not persisted.

The pane bar grows a chip that names the active word and clears it on click, the hidden-files footer and the all-hidden empty state say what the word hid, and / now summons the rail (and the Files tab) when collapsed, focusing the box from Nav's own effect after the reveal commits — focusing from the key handler raced the un-hide, and a display:none input swallows focus().