### PR TITLE
fix: make Hide tests find the tests in any stack, not just JavaScript

### DIFF
--- a/src/ui/reviewFilter.test.ts
+++ b/src/ui/reviewFilter.test.ts
@@ -24,6 +24,57 @@ describe('isTestFile', () => {
     expect(isTestFile('src/a.ts')).toBe(false)
     expect(isTestFile('src/testing/a.ts')).toBe(false)
   })
+
+  it('catches the PascalCase suffix .NET and Java name their tests with', () => {
+    expect(isTestFile('MyApp.Tests/UserServiceTests.cs')).toBe(true)
+    expect(isTestFile('src/MyApp.Tests/OrderTests.cs')).toBe(true)
+    expect(isTestFile('src/UserServiceTest.cs')).toBe(true)
+    expect(isTestFile('src/test/java/com/x/FooTest.java')).toBe(true)
+    expect(isTestFile('Tests.cs')).toBe(true)
+    expect(isTestFile('src/UserService.cs')).toBe(false)
+  })
+
+  it('catches a .NET test project by its directory and its csproj', () => {
+    expect(isTestFile('MyApp.Tests/MyApp.Tests.csproj')).toBe(true)
+    expect(isTestFile('MyApp.Tests.csproj')).toBe(true)
+    expect(isTestFile('src/MyApp.Test/Helpers.cs')).toBe(true)
+    expect(isTestFile('src/MyApp/MyApp.csproj')).toBe(false)
+  })
+
+  it('catches the test, tests and spec directories other stacks use', () => {
+    expect(isTestFile('tests/OrderTest.cs')).toBe(true)
+    expect(isTestFile('test/Foo.cs')).toBe(true)
+    expect(isTestFile('spec/models/user_spec.rb')).toBe(true)
+    expect(isTestFile('src/main/java/com/x/Foo.java')).toBe(false)
+  })
+
+  it('catches a capitalised Tests directory, which is how Unity and .NET spell it', () => {
+    expect(isTestFile('Assets/Tests/EditMode/PlayerMovement.cs')).toBe(true)
+    expect(isTestFile('Assets/Tests/EditMode/Tests.asmdef')).toBe(true)
+    expect(isTestFile('src/MyApp/Test/Helper.cs')).toBe(true)
+    // Odin Inspector is the reason the directory rule stays anchored: "Inspector"
+    // contains "spec", and a real Unity project is full of it.
+    expect(isTestFile('Assets/ThirdParty/Sirenix/Odin Inspector/Scripts/Foo.cs')).toBe(false)
+    expect(isTestFile('Assets/Sirenix.OdinInspector.Editor.dll')).toBe(false)
+  })
+
+  it('catches the snake and prefix spellings Go, Python and Ruby use', () => {
+    expect(isTestFile('internal/foo_test.go')).toBe(true)
+    expect(isTestFile('tests/test_parser.py')).toBe(true)
+    expect(isTestFile('app/models/user_spec.rb')).toBe(true)
+    expect(isTestFile('internal/foo.go')).toBe(false)
+    expect(isTestFile('app/parser.py')).toBe(false)
+  })
+
+  it('leaves source alone when a word merely ends in test', () => {
+    expect(isTestFile('src/Latest.cs')).toBe(false)
+    expect(isTestFile('src/Contest.cs')).toBe(false)
+    expect(isTestFile('src/Protest/Protester.cs')).toBe(false)
+    expect(isTestFile('src/latest.ts')).toBe(false)
+    expect(isTestFile('src/manifest.json')).toBe(false)
+    expect(isTestFile('src/fixtures/TestData.json')).toBe(false)
+    expect(isTestFile('src/attestation.go')).toBe(false)
+  })
 })
 
 describe('splitFiles', () => {

--- a/src/ui/reviewFilter.ts
+++ b/src/ui/reviewFilter.ts
@@ -1,8 +1,18 @@
 import { useCallback, useMemo, useState } from 'react'
 import type { FileChange } from '../shared/types.js'
 
+/** Case-sensitive on purpose: lowercased, these also hide `Latest.cs`. `spec/`
+ * is no directory rule — it holds API specs as often as tests. */
+const TEST_PATTERNS: readonly RegExp[] = [
+  /[._-](test|spec)s?\.[^/]+$/, // a.test.ts, foo_test.go, user_spec.rb, my-test.js
+  /(^|\/)test_[^/]+$/, // test_parser.py
+  /(^|\/)(__tests__|[Tt]ests?)\//, // src/__tests__/a.ts, tests/OrderTest.cs, Assets/Tests/
+  /(^|[/.a-z0-9])Tests?\.[^/]+$/, // UserServiceTests.cs, FooTest.java, MyApp.Tests.csproj
+  /\.Tests?\//, // MyApp.Tests/Order.cs — a .NET test project
+]
+
 export function isTestFile(path: string): boolean {
-  return /\.(test|spec)\.[^/]+$/.test(path) || /(^|\/)__tests__\//.test(path)
+  return TEST_PATTERNS.some((pattern) => pattern.test(path))
 }
 
 /** Above this many files, Hide reviewed starts on — a review this size needs it


### PR DESCRIPTION
Closes #21.

## The bug

`Hide tests` sat at 0 on a C# project and hid nothing. `isTestFile` recognised only the JavaScript spellings, so no `.cs` test file was ever classified:

```ts
return /\.(test|spec)\.[^/]+$/.test(path) || /(^|\/)__tests__\//.test(path)
```

That blind spot is not .NET-specific — Java, Go, Python and Ruby all fell through it too.

| Convention | Example | Before |
| --- | --- | --- |
| dot pair | `cliArgs.test.ts` | ✅ |
| `__tests__/` | `src/__tests__/a.ts` | ✅ |
| PascalCase suffix | `UserServiceTests.cs`, `FooTest.java` | ❌ |
| `.Tests` project dir | `MyApp.Tests/Order.cs` | ❌ |
| `test/` `tests/` `Tests/` | `tests/OrderTest.cs`, `Assets/Tests/Foo.cs` | ❌ |
| snake suffix | `foo_test.go`, `user_spec.rb` | ❌ |
| `test_` prefix | `tests/test_parser.py` | ❌ |

## The fix

One named list of patterns, still a pure path predicate with no new dependencies.

Two calls worth reviewing, both documented in the code:

- **The PascalCase rules are case-sensitive.** Lowercased they also match `Latest.cs`, `contest.py` and `attestation.go`.
- **`spec/` is not a directory rule.** It holds API specs as often as tests, and Ruby's own files end in `_spec.rb` anyway.

Both resolve the same way: hiding real source unread is a worse failure than leaving a test file on screen, so ambiguity resolves toward showing the file.

## Verification

- `pnpm check` green — 905 tests across 55 files, 6 new cases in `reviewFilter.test.ts`
- Audited over this repo's 216 tracked files: 55 flagged, 55 actual, 0 false positives, 0 false negatives
- Audited over a real 568-file Unity/C# project: nothing hidden, including the 70 paths containing `Inspector` (which contains "spec")
- Checked by hand in the review UI on a C# fixture: the toggle appears and reads 6, while `Latest.cs` and `Contest.cs` stay visible

The capitalised `Tests/` rule came out of that Unity project — `Assets/Tests/` is the Unity layout and common in .NET, and a lowercase-only rule missed it.

I have read the CLA Document and I hereby sign the CLA

