### PR TITLE
feat: comment on multiple lines

### DIFF
--- a/src/server/review.test.ts
+++ b/src/server/review.test.ts
@@ -374,6 +374,33 @@ describe('parseReview', () => {
     expect(parsed!.threads.map((t) => t.id)).toEqual(['ok'])
   })
 
+  it('a range anchor survives the round trip — endLine must not vanish on reload', () => {
+    const stored = (endLine: unknown) =>
+      JSON.stringify({
+        threads: [
+          {
+            id: 't',
+            state: 'open',
+            anchor: { kind: 'hunk', hunkId: 'h', path: 'a.ts', side: 'new', line: 4, endLine },
+            messages: [{ author: 'reviewer', text: 'hi' }],
+          },
+        ],
+      })
+    expect(parseReview(stored(9))!.threads[0]!.anchor).toEqual({
+      kind: 'hunk',
+      hunkId: 'h',
+      path: 'a.ts',
+      side: 'new',
+      line: 4,
+      endLine: 9,
+    })
+    // A span that doesn't extend past its start collapses back to a single line.
+    for (const bad of [4, 3, 4.5, '9', null]) {
+      const anchor = parseReview(stored(bad))!.threads[0]!.anchor
+      expect(anchor).toEqual({ kind: 'hunk', hunkId: 'h', path: 'a.ts', side: 'new', line: 4 })
+    }
+  })
+
   it('returns null for non-review JSON', () => {
     expect(parseReview('[]')).toBeNull()
     expect(parseReview('{"threads": 5}')).toBeNull()

--- a/src/server/review.ts
+++ b/src/server/review.ts
@@ -487,12 +487,21 @@ export function parseAnchor(value: unknown): Anchor | null {
     if (typeof anchor.hunkId !== 'string' || typeof anchor.path !== 'string') return null
     if (anchor.side !== 'old' && anchor.side !== 'new') return null
     if (typeof anchor.line !== 'number') return null
+    // A range's end must extend past its start — anything else collapses back to a
+    // single line rather than persisting a degenerate span.
+    const endLine =
+      typeof anchor.endLine === 'number' &&
+      Number.isInteger(anchor.endLine) &&
+      anchor.endLine > anchor.line
+        ? anchor.endLine
+        : undefined
     return {
       kind: 'hunk',
       hunkId: anchor.hunkId,
       path: anchor.path,
       side: anchor.side,
       line: anchor.line,
+      ...(endLine !== undefined ? { endLine } : {}),
     }
   }
   if (anchor.kind === 'file') {

--- a/src/shared/review.test.ts
+++ b/src/shared/review.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest'
-import { type ReviewThread, threadsInChangeset, undeliveredThreadIds } from './review.js'
+import {
+  anchorSpan,
+  describeAnchor,
+  type ReviewThread,
+  threadsInChangeset,
+  undeliveredThreadIds,
+} from './review.js'
 import type { DiffLine, FileChange, Hunk } from './types.js'
 
 const add = (newNo: number): DiffLine => ({ kind: 'add', oldNo: null, newNo, text: 'added' })
@@ -106,5 +112,21 @@ describe('undeliveredThreadIds — what a restart still owes the agent', () => {
   it('still re-queues the others alongside it, in send order', () => {
     const ids = undeliveredThreadIds([sent('3'), sent('1', { withheld: true }), sent('2')])
     expect(ids).toEqual(['2', '3'])
+  })
+})
+
+describe('anchorSpan / describeAnchor — the one label the agent ever sees', () => {
+  const single = { kind: 'hunk', hunkId: 'h', path: 'a.ts', side: 'new', line: 12 } as const
+
+  it('a single line stays a bare number; a range reads start-end', () => {
+    expect(anchorSpan(single)).toBe('12')
+    expect(anchorSpan({ ...single, endLine: 20 })).toBe('12-20')
+  })
+
+  it('describeAnchor carries the range through to the prompt', () => {
+    expect(describeAnchor(single)).toBe('a.ts:12 (new side)')
+    expect(describeAnchor({ ...single, endLine: 20 })).toBe('a.ts:12-20 (new side)')
+    expect(describeAnchor({ kind: 'file', path: 'a.ts' })).toBe('a.ts')
+    expect(describeAnchor({ kind: 'changeset' })).toBe('the whole changeset')
   })
 })

--- a/src/shared/review.ts
+++ b/src/shared/review.ts
@@ -7,7 +7,16 @@ export type ThreadIntent = 'question' | 'fix'
 export const THREAD_INTENTS: readonly ThreadIntent[] = ['fix', 'question']
 
 export type Anchor =
-  | { kind: 'hunk'; hunkId: string; path: string; side: 'old' | 'new'; line: number }
+  /** `line` is the first (or only) anchored line; `endLine` widens it to a range.
+   * Absent `endLine` ⇒ a single line, so every pre-range anchor is already valid. */
+  | {
+      kind: 'hunk'
+      hunkId: string
+      path: string
+      side: 'old' | 'new'
+      line: number
+      endLine?: number
+    }
   | { kind: 'file'; path: string }
   | { kind: 'changeset' }
 
@@ -198,8 +207,13 @@ export function threadsInChangeset(
   return { active, past }
 }
 
+/** The line part of a hunk anchor's label: `12`, or `12-20` for a range. */
+export function anchorSpan(anchor: Extract<Anchor, { kind: 'hunk' }>): string {
+  return anchor.endLine === undefined ? `${anchor.line}` : `${anchor.line}-${anchor.endLine}`
+}
+
 export function describeAnchor(anchor: Anchor): string {
   if (anchor.kind === 'changeset') return 'the whole changeset'
   if (anchor.kind === 'file') return anchor.path
-  return `${anchor.path}:${anchor.line} (${anchor.side} side)`
+  return `${anchor.path}:${anchorSpan(anchor)} (${anchor.side} side)`
 }

--- a/src/ui/components/CommentBox.tsx
+++ b/src/ui/components/CommentBox.tsx
@@ -81,6 +81,14 @@ function applyToolbar(
 export interface CommentBoxScope {
   label: string
   canWiden: boolean
+  /** Range steppers on the chip: one dial, not two jobs. The line the composer
+   * was opened on is the range's fixed anchor; each press walks the OTHER edge
+   * one line up or down — through the anchor and out the far side, so ▼▼▼ from a
+   * single line reads "this line as top, three lines down". Every press has an
+   * exact inverse, so no selection is ever lost. Also how a single-line comment
+   * quietly teaches that ranges exist at all. Absent ⇒ that direction is at the
+   * rendered window's limit. */
+  adjust?: { up?: () => void; down?: () => void }
 }
 
 export function CommentBox({
@@ -92,6 +100,10 @@ export function CommentBox({
   onCancel,
   agentConnected = false,
   autoFocus = true,
+  draft,
+  onDraft,
+  draftIntent,
+  onDraftIntent,
 }: {
   title: string
   placeholder: string
@@ -101,15 +113,26 @@ export function CommentBox({
   onCancel: () => void
   agentConnected?: boolean
   autoFocus?: boolean
+  /** Controlled draft. A range composer's row moves with the range's last line,
+   * which re-mounts this component — the owner holds the words (and the intent)
+   * so growing the range can never eat a half-typed comment. */
+  draft?: string
+  onDraft?: (text: string) => void
+  draftIntent?: ThreadIntent
+  onDraftIntent?: (intent: ThreadIntent | undefined) => void
 }) {
-  const [text, setText] = useState('')
+  const [ownText, setOwnText] = useState('')
   const [tab, setTab] = useState<'write' | 'preview'>('write')
   const [wide, setWide] = useState(false)
   // Unset by default: most comments say what they want on their own, and the agent
   // is told to judge unlabeled threads from the text. The chips force a reading
   // only when the words alone could be taken either way.
-  const [intent, setIntent] = useState<ThreadIntent | undefined>(undefined)
+  const [ownIntent, setOwnIntent] = useState<ThreadIntent | undefined>(undefined)
   const [rich, setRich] = useState(false)
+  const text = onDraft ? (draft ?? '') : ownText
+  const setText = onDraft ?? setOwnText
+  const intent = onDraftIntent ? draftIntent : ownIntent
+  const setIntent = onDraftIntent ?? setOwnIntent
   const box = useRef<HTMLTextAreaElement>(null)
   const ready = text.trim().length > 0
 
@@ -135,6 +158,30 @@ export function CommentBox({
             <span className="scope-chip">
               <Icon name={wide ? 'cmp' : 'unified'} size="sm" />
               {wide ? 'the whole changeset' : scope.label}
+              {!wide && scope.adjust && (
+                <span className="scope-chip-steppers">
+                  <button
+                    type="button"
+                    className="scope-chip-step"
+                    disabled={!scope.adjust.up}
+                    title="walk the range's edge one line up — the line you started on stays put"
+                    aria-label="range edge one line up"
+                    onClick={scope.adjust.up}
+                  >
+                    <Icon name="up" size="sm" />
+                  </button>
+                  <button
+                    type="button"
+                    className="scope-chip-step"
+                    disabled={!scope.adjust.down}
+                    title="walk the range's edge one line down — the line you started on stays put"
+                    aria-label="range edge one line down"
+                    onClick={scope.adjust.down}
+                  >
+                    <Icon name="down" size="sm" />
+                  </button>
+                </span>
+              )}
               {wide && scope.canWiden && (
                 <button
                   type="button"

--- a/src/ui/components/FinishReview.tsx
+++ b/src/ui/components/FinishReview.tsx
@@ -1,5 +1,11 @@
 import { useEffect, useState } from 'react'
-import type { Anchor, Coverage, OutgoingThread, ReviewVerdict } from '../../shared/review.js'
+import {
+  type Anchor,
+  anchorSpan,
+  type Coverage,
+  type OutgoingThread,
+  type ReviewVerdict,
+} from '../../shared/review.js'
 import { type Presence, useFinishPreview } from '../api.js'
 import { copyText } from '../clipboard.js'
 import type { ThreadItem } from '../threads.js'
@@ -29,7 +35,7 @@ const ROWS = 4
 function rowAnchor(anchor: Anchor): string {
   if (anchor.kind === 'changeset') return 'the whole changeset'
   if (anchor.kind === 'file') return anchor.path
-  return `${anchor.path}:${anchor.line}${anchor.side === 'old' ? ' (old side)' : ''}`
+  return `${anchor.path}:${anchorSpan(anchor)}${anchor.side === 'old' ? ' (old side)' : ''}`
 }
 
 export function FinishReview({

--- a/src/ui/components/HunkCard.test.tsx
+++ b/src/ui/components/HunkCard.test.tsx
@@ -1,8 +1,9 @@
 // @vitest-environment jsdom
-import { cleanup, render, screen } from '@testing-library/react'
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { Hunk } from '../../shared/types.js'
 import { HunkCard } from './HunkCard.js'
+import type { ReviewActions } from './Threads.js'
 
 vi.mock('../highlight.js', () => ({
   tokenizeLines: async () => null,
@@ -21,6 +22,179 @@ const HUNK: Hunk = {
     { kind: 'add', oldNo: null, newNo: 714, text: '  const unsubscribeBatch = 1' },
   ],
 }
+
+const WIDE_HUNK: Hunk = {
+  id: 'h9',
+  path: 'src/a.ts',
+  oldStart: 1,
+  newStart: 1,
+  lines: [
+    { kind: 'context', oldNo: 1, newNo: 1, text: 'const a = 1' },
+    { kind: 'add', oldNo: null, newNo: 2, text: 'const b = 2' },
+    { kind: 'add', oldNo: null, newNo: 3, text: 'const c = 3' },
+    { kind: 'context', oldNo: 2, newNo: 4, text: 'export {}' },
+  ],
+}
+
+function actionsStub(): ReviewActions {
+  return {
+    create: vi.fn().mockResolvedValue({ id: 't' }),
+    reply: vi.fn(),
+    send: vi.fn().mockResolvedValue({ delivered: true }),
+    resolve: vi.fn(),
+    reopen: vi.fn(),
+  }
+}
+
+describe('multi-line comments', () => {
+  it('a gutter drag opens the composer on the range, and the anchor carries it', () => {
+    const actions = actionsStub()
+    const { container } = render(<HunkCard hunk={WIDE_HUNK} reviewActions={actions} />)
+    const rows = [...container.querySelectorAll('tr.line')]
+    fireEvent.mouseDown(rows[1]!.querySelector('.line-no')!, { button: 0 })
+    fireEvent.mouseEnter(rows[2]!)
+    fireEvent.mouseUp(document)
+
+    // The dragged rows are marked, and the chip names the span.
+    expect(container.querySelectorAll('tr.line-sel').length).toBe(2)
+    expect(screen.getByText('a.ts:2-3')).toBeTruthy()
+
+    fireEvent.change(screen.getByPlaceholderText('Leave a comment…'), {
+      target: { value: 'these two belong together' },
+    })
+    fireEvent.click(screen.getByText('Add comment'))
+    expect(actions.create).toHaveBeenCalledWith(
+      { kind: 'hunk', hunkId: 'h9', path: 'src/a.ts', side: 'new', line: 2, endLine: 3 },
+      'these two belong together',
+      undefined,
+    )
+  })
+
+  it('an upward drag lands the composer under the bottom line all the same', () => {
+    const actions = actionsStub()
+    const { container } = render(<HunkCard hunk={WIDE_HUNK} reviewActions={actions} />)
+    const rows = [...container.querySelectorAll('tr.line')]
+    fireEvent.mouseDown(rows[2]!.querySelector('.line-no')!, { button: 0 })
+    fireEvent.mouseEnter(rows[1]!)
+    fireEvent.mouseUp(document)
+    expect(screen.getByText('a.ts:2-3')).toBeTruthy()
+    // The composer row sits after the range's last line, not its first.
+    const composerRow = container.querySelector('.thread-row')!
+    expect(composerRow.previousElementSibling).toBe(rows[2])
+  })
+
+  it('the steppers walk one free edge through the anchor — every press reversible', () => {
+    const actions = actionsStub()
+    const { container } = render(<HunkCard hunk={WIDE_HUNK} reviewActions={actions} />)
+    const rows = [...container.querySelectorAll('tr.line')]
+    fireEvent.mouseDown(rows[2]!.querySelector('.line-no')!, { button: 0 })
+    fireEvent.mouseUp(document)
+    expect(screen.getByText('a.ts:3')).toBeTruthy()
+
+    // Up: the edge climbs above the anchor; the composer stays on the anchor row.
+    fireEvent.click(screen.getByLabelText('range edge one line up'))
+    expect(screen.getByText('a.ts:2-3')).toBeTruthy()
+    expect(container.querySelector('.thread-row')!.previousElementSibling).toBe(rows[2])
+    fireEvent.click(screen.getByLabelText('range edge one line up'))
+    expect(screen.getByText('a.ts:1-3')).toBeTruthy()
+
+    // Down is up's exact inverse…
+    fireEvent.click(screen.getByLabelText('range edge one line down'))
+    expect(screen.getByText('a.ts:2-3')).toBeTruthy()
+    fireEvent.click(screen.getByLabelText('range edge one line down'))
+    expect(screen.getByText('a.ts:3')).toBeTruthy()
+
+    // …and past the anchor it keeps going: anchor as top, edge below.
+    fireEvent.click(screen.getByLabelText('range edge one line down'))
+    expect(screen.getByText('a.ts:3-4')).toBeTruthy()
+    expect(container.querySelector('.thread-row')!.previousElementSibling).toBe(rows[3])
+    // The edge sits on the hunk's last rendered line — down is out of road.
+    expect(screen.getByLabelText('range edge one line down')).toHaveProperty('disabled', true)
+  })
+
+  it('walking the edge below moves the composer down without eating the draft', () => {
+    const actions = actionsStub()
+    const { container } = render(<HunkCard hunk={WIDE_HUNK} reviewActions={actions} />)
+    const rows = [...container.querySelectorAll('tr.line')]
+    fireEvent.mouseDown(rows[1]!.querySelector('.line-no')!, { button: 0 })
+    fireEvent.mouseUp(document)
+    fireEvent.change(screen.getByPlaceholderText('Leave a comment…'), {
+      target: { value: 'half a thought' },
+    })
+
+    fireEvent.click(screen.getByLabelText('range edge one line down'))
+    expect(screen.getByText('a.ts:2-3')).toBeTruthy()
+    // The composer re-parented under the new last line — and the words survived.
+    expect(container.querySelector('.thread-row')!.previousElementSibling).toBe(rows[2])
+    expect(screen.getByPlaceholderText('Leave a comment…')).toHaveProperty(
+      'value',
+      'half a thought',
+    )
+  })
+
+  it('shift-click puts the free edge on the clicked line; the anchor never moves', () => {
+    const actions = actionsStub()
+    const { container } = render(<HunkCard hunk={WIDE_HUNK} reviewActions={actions} />)
+    const rows = [...container.querySelectorAll('tr.line')]
+    fireEvent.mouseDown(rows[3]!.querySelector('.line-no')!, { button: 0 })
+    fireEvent.mouseUp(document)
+    fireEvent.mouseDown(rows[1]!.querySelector('.line-no')!, { button: 0, shiftKey: true })
+    expect(screen.getByText('a.ts:2-4')).toBeTruthy()
+    expect(container.querySelectorAll('tr.line-sel').length).toBe(3)
+
+    // A second shift-click just moves the same edge again — the anchor holds.
+    fireEvent.mouseDown(rows[2]!.querySelector('.line-no')!, { button: 0, shiftKey: true })
+    expect(screen.getByText('a.ts:3-4')).toBeTruthy()
+    expect(container.querySelectorAll('tr.line-sel').length).toBe(2)
+  })
+
+  it('rows spanned by an existing range thread carry the quiet gutter mark', () => {
+    const { container } = render(
+      <HunkCard
+        hunk={WIDE_HUNK}
+        reviewActions={actionsStub()}
+        threads={[
+          {
+            id: 'r',
+            anchor: {
+              kind: 'hunk',
+              hunkId: 'h9',
+              path: 'src/a.ts',
+              side: 'new',
+              line: 2,
+              endLine: 4,
+            },
+            state: 'open',
+            codeContext: null,
+            codeChanged: false,
+            messages: [{ id: 'm', author: 'reviewer', text: 'span', at: '2026-01-01' }],
+            createdAt: '2026-01-01',
+            updatedAt: '2026-01-01',
+          },
+        ]}
+      />,
+    )
+    expect(container.querySelectorAll('tr.line-ranged').length).toBe(3)
+    // The glyph sits on the range's first line only.
+    const glyphs = container.querySelectorAll('.line-range-glyph')
+    expect(glyphs.length).toBe(1)
+    expect(glyphs[0]!.closest('tr')).toBe(container.querySelectorAll('tr.line')[1])
+    // And the card renders under the range's last line, with the bracket's spine
+    // carried through its own row.
+    const rows = [...container.querySelectorAll('tr.line')]
+    const cardRow = container.querySelector('tr.thread-row')!
+    expect(cardRow.previousElementSibling).toBe(rows[3])
+    expect(cardRow.classList.contains('thread-row-ranged')).toBe(true)
+
+    // Hovering the card lights the whole range it spans — spine included.
+    fireEvent.mouseEnter(container.querySelector('.thread-anchor-scope')!)
+    expect(container.querySelectorAll('tr.line-sel').length).toBe(3)
+    expect(cardRow.classList.contains('thread-row-lit')).toBe(true)
+    fireEvent.mouseLeave(container.querySelector('.thread-anchor-scope')!)
+    expect(container.querySelectorAll('tr.line-sel').length).toBe(0)
+    expect(cardRow.classList.contains('thread-row-lit')).toBe(false)
+  })
+})
 
 describe('changed since your last review', () => {
   it('marks the hunk durably with the bar alone — the words live in the file header', () => {

--- a/src/ui/components/HunkCard.tsx
+++ b/src/ui/components/HunkCard.tsx
@@ -1,15 +1,33 @@
 import { Fragment, type ReactNode, useEffect, useMemo, useState } from 'react'
 import type { ReviewThread } from '../../shared/review.js'
+import { anchorSpan, type ThreadIntent } from '../../shared/review.js'
 import type { DiffLine, Hunk } from '../../shared/types.js'
 import { EXPAND_STEP } from '../gaps.js'
 import { type LineTokens, tokenizeLines } from '../highlight.js'
 import { useDarkMode } from '../hooks.js'
 import { intralineRanges, type Range, splitByRanges } from '../intraline.js'
-import { anchorForLine, threadsByLine } from '../reviewPlacement.js'
+import { anchorForRange, rangedRows, rangeStartRows, threadsByLine } from '../reviewPlacement.js'
 import { toSplitRows } from '../splitRows.js'
 import { Icon } from './Icon.js'
 import type { ViewMode } from './ReadingPane.js'
 import { CommentBox, type ReviewActions, ThreadList } from './Threads.js'
+
+/** A run of rendered line indices, inclusive, in either order. */
+interface LineSpan {
+  start: number
+  end: number
+}
+
+/**
+ * The open composer's range, anchor-model: `at` is the row the composer was
+ * opened on and never moves; `edge` is the other endpoint, free to walk up or
+ * down — through `at` and out the far side. The rendered range is always
+ * [min, max] of the two, and the composer card sits under the max.
+ */
+interface ComposeRange {
+  at: number
+  edge: number
+}
 
 /**
  * One hidden region's controls, owned by the file (a gap is shared between the two
@@ -240,8 +258,57 @@ const MARKER: Record<DiffLine['kind'], string> = { add: '+', del: '−', context
 
 interface LineExtras {
   extraFor?: (lineIdx: number) => ReactNode
+  /** Extra classes for the thread-row hosting extraFor's card(s) — carries the
+   * range bracket's spine through the card row. */
+  extraClass?: (lineIdx: number) => string
   onComment?: (lineIdx: number) => void
+  /** Mousedown in a line-number gutter — where a range drag (or a shift-click
+   * extension of the open composer) begins. */
+  onGutterDown?: (lineIdx: number, shiftKey: boolean) => void
+  /** The pointer crossed onto this line mid-drag. */
+  onLineEnter?: (lineIdx: number) => void
+  selRows?: ReadonlySet<number>
+  rangeRows?: ReadonlySet<number>
+  /** First row of each range thread — hosts the gutter glyph. */
+  rangeStarts?: ReadonlySet<number>
   ranges?: (Range[] | null)[]
+}
+
+/** The at-rest shape saying "a range conversation starts on this line" — a glyph
+ * survives every row tint where a colored bar drowns. Hidden while the row is
+ * hovered so it never fights the comment button that appears in the same spot. */
+function RangeGlyph() {
+  return (
+    <span className="line-range-glyph" aria-hidden="true">
+      <Icon name="chat" size="sm" />
+    </span>
+  )
+}
+
+/** The selection / commented-range classes for a rendered row (split rows answer
+ * for both halves). Leading space so it appends straight onto the base class. */
+function rowClass(
+  selRows: ReadonlySet<number> | undefined,
+  rangeRows: ReadonlySet<number> | undefined,
+  ...idxs: (number | undefined)[]
+): string {
+  const has = (set: ReadonlySet<number> | undefined) =>
+    set !== undefined && idxs.some((i) => i !== undefined && set.has(i))
+  return `${has(selRows) ? ' line-sel' : ''}${has(rangeRows) ? ' line-ranged' : ''}`
+}
+
+/** Left-button gutter presses start a drag; preventDefault keeps the browser from
+ * beginning a text selection that would then smear across the code cells. */
+function gutterDown(
+  onGutterDown: ((lineIdx: number, shiftKey: boolean) => void) | undefined,
+  idx: number,
+): ((e: React.MouseEvent) => void) | undefined {
+  if (!onGutterDown) return undefined
+  return (e) => {
+    if (e.button !== 0) return
+    e.preventDefault()
+    onGutterDown(idx, e.shiftKey)
+  }
 }
 
 function CommentButton({ onClick }: { onClick: () => void }) {
@@ -249,11 +316,13 @@ function CommentButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       className="line-comment-btn"
-      title="comment on this line"
-      aria-label="comment on this line"
+      title="comment on this line — drag down to take more lines"
+      aria-label="comment on this line, or drag down to comment on a range"
       onClick={(e) => {
         e.stopPropagation()
-        onClick()
+        // A shift-click is a range extension, handled on mousedown by the gutter —
+        // re-opening a single-line composer here would throw that range away.
+        if (!e.shiftKey) onClick()
       }}
     >
       <Icon name="plus" size="sm" />
@@ -266,7 +335,13 @@ function UnifiedLines({
   tokens,
   ranges,
   extraFor,
+  extraClass,
   onComment,
+  onGutterDown,
+  onLineEnter,
+  selRows,
+  rangeRows,
+  rangeStarts,
   boundary,
 }: { lines: DiffLine[]; tokens: (LineTokens | null)[]; boundary?: ReactNode } & LineExtras) {
   return (
@@ -275,22 +350,29 @@ function UnifiedLines({
         {boundary}
         {lines.map((line, i) => {
           const extra = extraFor?.(i)
+          const down = gutterDown(onGutterDown, i)
           return (
             // biome-ignore lint/suspicious/noArrayIndexKey: the hunk is keyed by content, so its rows never reorder
             <Fragment key={i}>
-              <tr className={`line line-${line.kind}`}>
-                <td className="line-no">
+              <tr
+                className={`line line-${line.kind}${rowClass(selRows, rangeRows, i)}`}
+                onMouseEnter={onLineEnter ? () => onLineEnter(i) : undefined}
+              >
+                <td className="line-no" onMouseDown={down}>
+                  {rangeStarts?.has(i) && <RangeGlyph />}
                   {onComment && <CommentButton onClick={() => onComment(i)} />}
                   {line.oldNo ?? ''}
                 </td>
-                <td className="line-no">{line.newNo ?? ''}</td>
+                <td className="line-no" onMouseDown={down}>
+                  {line.newNo ?? ''}
+                </td>
                 <td className="line-marker">{MARKER[line.kind]}</td>
                 <td className="line-code">
                   <CodeText line={line} tokens={tokens[i] ?? null} ranges={ranges?.[i]} />
                 </td>
               </tr>
               {extra && (
-                <tr className="thread-row">
+                <tr className={`thread-row${extraClass?.(i) ?? ''}`}>
                   <td colSpan={4}>{extra}</td>
                 </tr>
               )}
@@ -307,10 +389,20 @@ function SplitLines({
   tokens,
   ranges,
   extraFor,
+  extraClass,
   onComment,
+  onGutterDown,
+  onLineEnter,
+  selRows,
+  rangeRows,
+  rangeStarts,
   boundary,
 }: { lines: DiffLine[]; tokens: (LineTokens | null)[]; boundary?: ReactNode } & LineExtras) {
   const rows = toSplitRows(lines)
+  // Each half of a split row is its own line, so the drag handlers ride the cells
+  // rather than the row — crossing onto either half extends to that half's line.
+  const enter = (idx: number | undefined) =>
+    onLineEnter && idx !== undefined ? () => onLineEnter(idx) : undefined
   return (
     <table className="hunk-lines hunk-lines-split">
       {/* table-layout: fixed sizes columns from the first row, and that row is the
@@ -331,14 +423,22 @@ function SplitLines({
           return (
             // biome-ignore lint/suspicious/noArrayIndexKey: the hunk is keyed by content, so its rows never reorder
             <Fragment key={i}>
-              <tr className="line">
-                <td className="line-no">
+              <tr className={`line${rowClass(selRows, rangeRows, row.left?.idx, row.right?.idx)}`}>
+                <td
+                  className="line-no"
+                  onMouseDown={row.left ? gutterDown(onGutterDown, row.left.idx) : undefined}
+                  onMouseEnter={enter(row.left?.idx)}
+                >
+                  {row.left && rangeStarts?.has(row.left.idx) && <RangeGlyph />}
                   {onComment && row.left && (
                     <CommentButton onClick={() => onComment(row.left!.idx)} />
                   )}
                   {row.left?.line.oldNo ?? ''}
                 </td>
-                <td className={`line-half line-half-${row.left?.line.kind ?? 'empty'}`}>
+                <td
+                  className={`line-half line-half-${row.left?.line.kind ?? 'empty'}`}
+                  onMouseEnter={enter(row.left?.idx)}
+                >
                   {row.left && (
                     <CodeText
                       line={row.left.line}
@@ -347,13 +447,21 @@ function SplitLines({
                     />
                   )}
                 </td>
-                <td className="line-no">
+                <td
+                  className="line-no"
+                  onMouseDown={row.right ? gutterDown(onGutterDown, row.right.idx) : undefined}
+                  onMouseEnter={enter(row.right?.idx)}
+                >
+                  {row.right && rangeStarts?.has(row.right.idx) && <RangeGlyph />}
                   {onComment && row.right && (
                     <CommentButton onClick={() => onComment(row.right!.idx)} />
                   )}
                   {row.right?.line.newNo ?? ''}
                 </td>
-                <td className={`line-half line-half-${row.right?.line.kind ?? 'empty'}`}>
+                <td
+                  className={`line-half line-half-${row.right?.line.kind ?? 'empty'}`}
+                  onMouseEnter={enter(row.right?.idx)}
+                >
                   {row.right && (
                     <CodeText
                       line={row.right.line}
@@ -364,7 +472,13 @@ function SplitLines({
                 </td>
               </tr>
               {(leftExtra || rightExtra) && (
-                <tr className="thread-row">
+                <tr
+                  className={`thread-row${
+                    (leftExtra && row.left && extraClass?.(row.left.idx)) ||
+                    (rightExtra && row.right && extraClass?.(row.right.idx)) ||
+                    ''
+                  }`}
+                >
                   <td colSpan={4}>
                     {leftExtra}
                     {rightExtra}
@@ -423,7 +537,11 @@ export function HunkCard({
   composeRequested?: boolean
   onComposeHandled?: () => void
 }) {
-  const [composerAt, setComposerAt] = useState<number | null>(null)
+  // The open composer's range (anchor + free edge) and a drag still in flight.
+  // The drag's press-point becomes the anchor, so the steppers and shift-click
+  // keep adjusting relative to the line the reviewer actually chose.
+  const [compose, setCompose] = useState<ComposeRange | null>(null)
+  const [drag, setDrag] = useState<LineSpan | null>(null)
 
   // Memoized so `lines` keeps a stable identity across renders: once expanded, an
   // unmemoized `[...linesAbove, ...hunk.lines]` was a fresh array every render, which
@@ -439,54 +557,142 @@ export function HunkCard({
   useEffect(() => {
     if (!composeRequested) return
     const idx = lines.findIndex((l) => l.kind !== 'context')
-    setComposerAt(idx === -1 ? 0 : idx)
+    const at = idx === -1 ? 0 : idx
+    setCompose({ at, edge: at })
     onComposeHandled?.()
   }, [composeRequested])
 
+  // The composer's words live up here, not in the CommentBox: growing the range
+  // downward moves the composer's row, which re-mounts the box — a draft it owned
+  // would be eaten mid-sentence.
+  const [draft, setDraft] = useState('')
+  const [draftIntent, setDraftIntent] = useState<ThreadIntent | undefined>(undefined)
+  const closeComposer = () => {
+    setCompose(null)
+    setDraft('')
+    setDraftIntent(undefined)
+  }
+
+  // The drag lives until the button comes back up anywhere on the page — the
+  // pointer routinely leaves the table mid-drag, so the listener is global.
+  useEffect(() => {
+    if (!drag) return
+    const up = () => {
+      setDrag(null)
+      setCompose({ at: drag.start, edge: drag.end })
+    }
+    window.addEventListener('mouseup', up)
+    return () => window.removeEventListener('mouseup', up)
+  }, [drag])
+
+  const onGutterDown = reviewActions
+    ? (idx: number, shiftKey: boolean) => {
+        // Shift-click puts the range's free edge on the clicked line — the anchor
+        // (where the composer was opened) stays put, exactly like extending a text
+        // selection from its origin. Fully reversible, so no line is ever lost.
+        if (shiftKey && compose) {
+          setCompose({ at: compose.at, edge: idx })
+          return
+        }
+        setDrag({ start: idx, end: idx })
+      }
+    : undefined
+  const onLineEnter = drag
+    ? (idx: number) => setDrag((d) => (d && d.end !== idx ? { ...d, end: idx } : d))
+    : undefined
+
   const lineThreads = threadsByLine(lines, threads)
   const strayThreads = lineThreads.get(-1) ?? []
+  const rangeRows = useMemo(() => rangedRows(lines, threads), [lines, threads])
+  const rangeStarts = useMemo(() => rangeStartRows(lines, threads), [lines, threads])
+  // Hovering a range thread's card lights the rows it spans — the card sits under
+  // the range's last line, and this is what ties it back to the rest of them. The
+  // idx names which thread-row is hovered, so its own spine can light up too.
+  const [hover, setHover] = useState<{ idx: number; rows: ReadonlySet<number> } | null>(null)
+  const selRows = useMemo(() => {
+    const span = drag ?? (compose ? { start: compose.at, end: compose.edge } : null)
+    const rows = new Set<number>(hover?.rows ?? [])
+    if (span) {
+      for (let i = Math.min(span.start, span.end); i <= Math.max(span.start, span.end); i++) {
+        rows.add(i)
+      }
+    }
+    return rows
+  }, [drag, compose, hover])
 
-  const composerFor = (idx: number): ReactNode => {
+  const composerFor = (span: ComposeRange): ReactNode => {
     if (!reviewActions) return null
-    const anchor = anchorForLine(hunk.id, hunk.path, lines[idx]!)
+    const anchor = anchorForRange(hunk.id, hunk.path, lines, span.at, span.edge)
     if (!anchor) return null
     const base = hunk.path.slice(hunk.path.lastIndexOf('/') + 1)
+    const label = `${base}:${anchorSpan(anchor)}`
     const anchorFor = (wide: boolean) => (wide ? ({ kind: 'changeset' } as const) : anchor)
     return (
       <CommentBox
-        title={`Comment on ${base}:${anchor.line}`}
+        title={`Comment on ${label}`}
         placeholder="Leave a comment…"
-        scope={{ label: `${base}:${anchor.line}`, canWiden: true }}
+        scope={{
+          label,
+          canWiden: true,
+          adjust: {
+            up: span.edge > 0 ? () => setCompose({ at: span.at, edge: span.edge - 1 }) : undefined,
+            down:
+              span.edge < lines.length - 1
+                ? () => setCompose({ at: span.at, edge: span.edge + 1 })
+                : undefined,
+          },
+        }}
         agentConnected={agentConnected}
+        draft={draft}
+        onDraft={setDraft}
+        draftIntent={draftIntent}
+        onDraftIntent={setDraftIntent}
         onSubmit={(text, wide, intent) => {
           void reviewActions.create(anchorFor(wide), text, intent)
-          setComposerAt(null)
+          closeComposer()
         }}
         onSend={(text, wide, intent) => {
           void reviewActions
             .create(anchorFor(wide), text, intent)
             .then((t) => reviewActions.send(t.id))
-          setComposerAt(null)
+          closeComposer()
         }}
-        onCancel={() => setComposerAt(null)}
+        onCancel={closeComposer}
       />
     )
   }
 
+  // The bracket's spine continues through the card's own row — muted at rest,
+  // blue while that card is hovered (its spanned lines light up in step).
+  const extraClass = (idx: number): string => {
+    const items = lineThreads.get(idx)
+    if (!items || rangedRows(lines, items).size === 0) return ''
+    return ` thread-row-ranged${hover?.idx === idx ? ' thread-row-lit' : ''}`
+  }
+
   const extraFor = (idx: number): ReactNode => {
     const items = lineThreads.get(idx)
-    const composer = composerAt === idx ? composerFor(idx) : null
+    const composer =
+      compose !== null && Math.max(compose.at, compose.edge) === idx ? composerFor(compose) : null
     if (!items && !composer) return null
+    const spanned = items ? rangedRows(lines, items) : new Set<number>()
     return (
       <>
         {items && reviewActions && (
-          <ThreadList
-            threads={items}
-            actions={reviewActions}
-            agentConnected={agentConnected}
-            workingOn={workingOn}
-            queuedOn={queuedOn}
-          />
+          // biome-ignore lint/a11y/noStaticElementInteractions: hover-only affordance — the lit range duplicates what the card's head already says in words
+          <div
+            className="thread-anchor-scope"
+            onMouseEnter={spanned.size > 0 ? () => setHover({ idx, rows: spanned }) : undefined}
+            onMouseLeave={spanned.size > 0 ? () => setHover(null) : undefined}
+          >
+            <ThreadList
+              threads={items}
+              actions={reviewActions}
+              agentConnected={agentConnected}
+              workingOn={workingOn}
+              queuedOn={queuedOn}
+            />
+          </div>
         )}
         {composer}
       </>
@@ -548,7 +754,13 @@ export function HunkCard({
           tokens={tokens}
           ranges={ranges}
           extraFor={extraFor}
-          onComment={reviewActions ? setComposerAt : undefined}
+          extraClass={extraClass}
+          onComment={reviewActions ? (idx) => setCompose({ at: idx, edge: idx }) : undefined}
+          onGutterDown={onGutterDown}
+          onLineEnter={onLineEnter}
+          selRows={selRows}
+          rangeRows={rangeRows}
+          rangeStarts={rangeStarts}
           boundary={boundary}
         />
       ) : (
@@ -557,7 +769,13 @@ export function HunkCard({
           tokens={tokens}
           ranges={ranges}
           extraFor={extraFor}
-          onComment={reviewActions ? setComposerAt : undefined}
+          extraClass={extraClass}
+          onComment={reviewActions ? (idx) => setCompose({ at: idx, edge: idx }) : undefined}
+          onGutterDown={onGutterDown}
+          onLineEnter={onLineEnter}
+          selRows={selRows}
+          rangeRows={rangeRows}
+          rangeStarts={rangeStarts}
           boundary={boundary}
         />
       )}

--- a/src/ui/components/Threads.tsx
+++ b/src/ui/components/Threads.tsx
@@ -1,5 +1,6 @@
 import { Fragment, useEffect, useRef, useState } from 'react'
 import {
+  anchorSpan,
   type ReviewThread,
   startedByAgent,
   type ThreadState,
@@ -538,8 +539,10 @@ function anchorLabel(thread: ReviewThread, gone = false): string {
   if (anchor.kind === 'changeset') {
     return startedByAgent(thread) ? `${word} on the changeset` : 'Note on the changeset'
   }
-  if (gone) return anchor.kind === 'hunk' ? `${anchor.path}:${anchor.line}` : anchor.path
-  if (anchor.kind === 'hunk') return `${word} on line ${anchor.line}`
+  if (gone) return anchor.kind === 'hunk' ? `${anchor.path}:${anchorSpan(anchor)}` : anchor.path
+  if (anchor.kind === 'hunk') {
+    return `${word} on ${anchor.endLine === undefined ? 'line' : 'lines'} ${anchorSpan(anchor)}`
+  }
   return `${word} on this file`
 }
 

--- a/src/ui/reviewPlacement.test.ts
+++ b/src/ui/reviewPlacement.test.ts
@@ -4,8 +4,12 @@ import type { DiffLine, FileChange, Hunk } from '../shared/types.js'
 import {
   anchorForHunk,
   anchorForLine,
+  anchorForRange,
   lineIndexForAnchor,
   partitionThreads,
+  placementIndexForAnchor,
+  rangedRows,
+  rangeStartRows,
   threadsByLine,
 } from './reviewPlacement.js'
 
@@ -122,6 +126,46 @@ describe('anchorForLine / anchorForHunk', () => {
   })
 })
 
+describe('anchorForRange', () => {
+  const lines = [ctx(1, 1), del(2), add(2), add(3), ctx(3, 4)]
+
+  it('the first line in the run picks the side; the last line on that side ends it', () => {
+    expect(anchorForRange('h', 'a.ts', lines, 0, 4)).toEqual({
+      kind: 'hunk',
+      hunkId: 'h',
+      path: 'a.ts',
+      side: 'new',
+      line: 1,
+      endLine: 4,
+    })
+    // Starting on the deletion makes it old-side — and the adds inside the run
+    // can't be its endpoint, so it clamps inward to the last old-numbered line.
+    expect(anchorForRange('h', 'a.ts', lines, 1, 3)).toEqual({
+      kind: 'hunk',
+      hunkId: 'h',
+      path: 'a.ts',
+      side: 'old',
+      line: 2,
+    })
+    expect(anchorForRange('h', 'a.ts', lines, 1, 4)).toMatchObject({
+      side: 'old',
+      line: 2,
+      endLine: 3,
+    })
+  })
+
+  it('a one-line run is a plain single-line anchor, endpoints in either order', () => {
+    expect(anchorForRange('h', 'a.ts', lines, 2, 2)).toEqual(anchorForLine('h', 'a.ts', add(2)))
+    expect(anchorForRange('h', 'a.ts', lines, 3, 0)).toEqual(
+      anchorForRange('h', 'a.ts', lines, 0, 3),
+    )
+  })
+
+  it('endpoints outside the window clamp instead of bailing', () => {
+    expect(anchorForRange('h', 'a.ts', lines, -3, 99)).toMatchObject({ line: 1, endLine: 4 })
+  })
+})
+
 describe('lineIndexForAnchor / threadsByLine', () => {
   const lines = [ctx(1, 1), del(2), add(2), add(3)]
 
@@ -152,5 +196,53 @@ describe('lineIndexForAnchor / threadsByLine', () => {
     ])
     expect(map.get(2)!.map((t) => t.id)).toEqual(['a', 'b'])
     expect(map.get(-1)!.map((t) => t.id)).toEqual(['c'])
+  })
+
+  it('a range thread renders under its last line, not its first', () => {
+    const map = threadsByLine(lines, [
+      thread('r', { kind: 'hunk', hunkId: 'h', path: 'p', side: 'new', line: 2, endLine: 3 }),
+    ])
+    expect(map.get(3)!.map((t) => t.id)).toEqual(['r'])
+  })
+
+  it('a range whose end was edited away falls back to its start line', () => {
+    const anchor = {
+      kind: 'hunk',
+      hunkId: 'h',
+      path: 'p',
+      side: 'new',
+      line: 2,
+      endLine: 99,
+    } as const
+    expect(placementIndexForAnchor(lines, anchor)).toBe(2)
+    const map = threadsByLine(lines, [thread('r', anchor)])
+    expect(map.get(2)!.map((t) => t.id)).toEqual(['r'])
+  })
+})
+
+describe('rangedRows', () => {
+  const lines = [ctx(1, 1), del(2), add(2), add(3), ctx(3, 4)]
+
+  it('marks every rendered row a range spans, and nothing for single lines', () => {
+    const rows = rangedRows(lines, [
+      thread('r', { kind: 'hunk', hunkId: 'h', path: 'p', side: 'new', line: 1, endLine: 3 }),
+      thread('s', { kind: 'hunk', hunkId: 'h', path: 'p', side: 'new', line: 4 }),
+    ])
+    expect([...rows].sort()).toEqual([0, 1, 2, 3])
+  })
+
+  it('says nothing when either endpoint left the window', () => {
+    const rows = rangedRows(lines, [
+      thread('r', { kind: 'hunk', hunkId: 'h', path: 'p', side: 'new', line: 90, endLine: 99 }),
+    ])
+    expect(rows.size).toBe(0)
+  })
+
+  it('rangeStartRows marks only each range’s first row — the glyph’s seat', () => {
+    const rows = rangeStartRows(lines, [
+      thread('r', { kind: 'hunk', hunkId: 'h', path: 'p', side: 'new', line: 1, endLine: 3 }),
+      thread('s', { kind: 'hunk', hunkId: 'h', path: 'p', side: 'new', line: 4 }),
+    ])
+    expect([...rows]).toEqual([0])
   })
 })

--- a/src/ui/reviewPlacement.ts
+++ b/src/ui/reviewPlacement.ts
@@ -91,17 +91,66 @@ export function anchorForHunk(hunk: Hunk): Anchor | null {
   return line ? anchorForLine(hunk.id, hunk.path, line) : null
 }
 
+/**
+ * Anchor for a comment on a dragged run of rendered lines. The *first* line in the
+ * run that carries a number picks the side — so a drag that starts on a deletion is
+ * an old-side range, and everything else is new-side. Lines with no number on that
+ * side (the other half of the diff, interleaved) don't break the range; they just
+ * can't be its endpoints, so the range clamps inward to the nearest line that counts.
+ * A range that clamps down to one line is a plain single-line anchor.
+ */
+export function anchorForRange(
+  hunkId: string,
+  path: string,
+  lines: DiffLine[],
+  from: number,
+  to: number,
+): Extract<Anchor, { kind: 'hunk' }> | null {
+  const lo = Math.max(0, Math.min(from, to))
+  const hi = Math.min(lines.length - 1, Math.max(from, to))
+  let start: Extract<Anchor, { kind: 'hunk' }> | null = null
+  for (let i = lo; i <= hi && !start; i++) start = anchorForLine(hunkId, path, lines[i]!)
+  if (!start) return null
+  const numberOn = (l: DiffLine) =>
+    start!.side === 'old' ? (l.kind !== 'add' ? l.oldNo : null) : l.kind !== 'del' ? l.newNo : null
+  let end = start.line
+  for (let i = hi; i > lo; i--) {
+    const n = numberOn(lines[i]!)
+    if (n !== null) {
+      end = n
+      break
+    }
+  }
+  return end > start.line ? { ...start, endLine: end } : start
+}
+
+function indexOfSideLine(lines: DiffLine[], side: 'old' | 'new', line: number): number {
+  return lines.findIndex((l) =>
+    side === 'old' ? l.kind !== 'add' && l.oldNo === line : l.kind !== 'del' && l.newNo === line,
+  )
+}
+
 /** Index in `lines` after which a hunk-anchored thread renders; -1 when the anchored
  * line isn't in the rendered window (thread renders at hunk end). */
 export function lineIndexForAnchor(
   lines: DiffLine[],
   anchor: Extract<Anchor, { kind: 'hunk' }>,
 ): number {
-  return lines.findIndex((l) =>
-    anchor.side === 'old'
-      ? l.kind !== 'add' && l.oldNo === anchor.line
-      : l.kind !== 'del' && l.newNo === anchor.line,
-  )
+  return indexOfSideLine(lines, anchor.side, anchor.line)
+}
+
+/** Where the thread's card actually sits: under the *last* line of a range (so the
+ * conversation reads below the code it is about), falling back to the start line
+ * when the end has been edited away, then to -1 like a single-line anchor. */
+export function placementIndexForAnchor(
+  lines: DiffLine[],
+  anchor: Extract<Anchor, { kind: 'hunk' }>,
+): number {
+  if (anchor.endLine !== undefined) {
+    const end = indexOfSideLine(lines, anchor.side, anchor.endLine)
+    if (end !== -1) return end
+  }
+  return lineIndexForAnchor(lines, anchor)
 }
 
 export function threadsByLine(
@@ -111,10 +160,42 @@ export function threadsByLine(
   const map = new Map<number, ReviewThread[]>()
   for (const thread of threads) {
     if (thread.anchor.kind !== 'hunk') continue
-    const index = lineIndexForAnchor(lines, thread.anchor)
+    const index = placementIndexForAnchor(lines, thread.anchor)
     const list = map.get(index)
     if (list) list.push(thread)
     else map.set(index, [thread])
   }
   return map
+}
+
+/** Rendered rows covered by some range-anchored thread — the quiet gutter bar that
+ * says "this conversation is about more than one line". Single-line anchors don't
+ * mark rows: their card already sits directly under the line. */
+export function rangedRows(lines: DiffLine[], threads: ReviewThread[]): Set<number> {
+  const rows = new Set<number>()
+  for (const thread of threads) {
+    const anchor = thread.anchor
+    if (anchor.kind !== 'hunk' || anchor.endLine === undefined) continue
+    const start = lineIndexForAnchor(lines, anchor)
+    const end = placementIndexForAnchor(lines, anchor)
+    if (start === -1 || end === -1) continue
+    for (let i = Math.min(start, end); i <= Math.max(start, end); i++) rows.add(i)
+  }
+  return rows
+}
+
+/** The first rendered row of each range-anchored thread — where the gutter glyph
+ * sits, the IDE-style "a conversation starts here" shape that survives every row
+ * tint. Single-line anchors don't get one; their card is already adjacent. */
+export function rangeStartRows(lines: DiffLine[], threads: ReviewThread[]): Set<number> {
+  const rows = new Set<number>()
+  for (const thread of threads) {
+    const anchor = thread.anchor
+    if (anchor.kind !== 'hunk' || anchor.endLine === undefined) continue
+    const start = lineIndexForAnchor(lines, anchor)
+    const end = placementIndexForAnchor(lines, anchor)
+    if (start === -1 || end === -1) continue
+    rows.add(Math.min(start, end))
+  }
+  return rows
 }

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -2990,6 +2990,71 @@ tr:hover .line-comment-btn {
   opacity: 1;
 }
 
+/*
+ * Rows an existing range-thread spans: an ink spine that also runs through the
+ * thread card's own row (`.thread-row-ranged`), so lines and card read as one
+ * bracket — without it, a sent multi-line comment looks single-line. A grey, not
+ * a tint: the gutter's left edge already speaks two tint languages (add/del row
+ * washes and marker insets), and a pale lavender drowned in them — value contrast
+ * is what reads over every row color in both themes. `--ink-3` specifically: full
+ * ink shouted, but the line numbers' own grey sits back like the rest of the
+ * gutter chrome. 2px so it rhymes with the add/del marker insets. The spine turns
+ * blue when the reviewer engages (hovering the card adds `.line-sel` to the
+ * spanned rows and `.thread-row-lit` to the card's row).
+ */
+.hunk-lines tr.line-ranged > td:first-child {
+  box-shadow: inset 2px 0 0 var(--ink-3);
+}
+
+.hunk-lines tr.thread-row-ranged > td {
+  box-shadow: inset 2px 0 0 var(--ink-3);
+}
+
+/*
+ * The at-rest shape: a small chat glyph on the range's first line — the IDE-gutter
+ * convention for "a conversation starts here", and per the palette's own rule the
+ * mark is a shape, never hue alone. Sits where the hover comment button lands, so
+ * it yields (fades) the moment the row is hovered.
+ */
+.line-range-glyph {
+  position: absolute;
+  left: 4px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: flex;
+  align-items: center;
+  color: var(--ink-2);
+  pointer-events: none;
+}
+
+.line-range-glyph svg {
+  width: 10px;
+  height: 10px;
+}
+
+tr:hover .line-range-glyph {
+  opacity: 0;
+}
+
+/*
+ * Range selection rides the cells, not the row: the add/del tints live on the tr,
+ * so a td background wins the cascade without !important and the drag reads the
+ * same over green, red and plain lines. Blue on purpose — the same borrowed GitHub
+ * hue as the gap expanders, and the one color that stays legible over both tints.
+ * After the resting-spine rules so that lit beats muted on the shared bar.
+ */
+.hunk-lines tr.line-sel > td {
+  background: var(--exp-wash);
+}
+
+.hunk-lines tr.line-sel > td:first-child {
+  box-shadow: inset 2px 0 0 var(--exp-ink);
+}
+
+.hunk-lines tr.thread-row-ranged.thread-row-lit > td {
+  box-shadow: inset 2px 0 0 var(--exp-ink);
+}
+
 .thread-row > td {
   padding: 0.35rem 0.8rem;
   background: var(--bg-subtle);
@@ -3680,6 +3745,40 @@ tr:hover .line-comment-btn {
   display: flex;
   align-items: center;
   justify-content: center;
+}
+
+.scope-chip-steppers {
+  display: inline-flex;
+  gap: 1px;
+}
+
+.scope-chip-step {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: 0;
+  padding: 0;
+  background: transparent;
+  color: var(--ink-3);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.scope-chip-step svg {
+  width: 9px;
+  height: 9px;
+}
+
+.scope-chip-step:hover:not(:disabled) {
+  background: var(--fill-2);
+  color: var(--ink);
+}
+
+.scope-chip-step:disabled {
+  opacity: 0.35;
+  cursor: default;
 }
 
 .scope-chip-x svg {

--- a/src/ui/threads.ts
+++ b/src/ui/threads.ts
@@ -1,4 +1,4 @@
-import { type ReviewThread, untouchedAgentVoice } from '../shared/review.js'
+import { anchorSpan, type ReviewThread, untouchedAgentVoice } from '../shared/review.js'
 
 export type Turn = 'yours' | 'unanswered' | 'proposed' | 'agent' | 'note' | 'resolved'
 
@@ -107,7 +107,7 @@ function describe(thread: ReviewThread): { anchor: string | null; path: string |
   const a = thread.anchor
   if (a.kind === 'changeset') return { anchor: null, path: null }
   if (a.kind === 'file') return { anchor: a.path, path: a.path }
-  return { anchor: `${a.path}:${a.line}`, path: a.path }
+  return { anchor: `${a.path}:${anchorSpan(a)}`, path: a.path }
 }
 
 export function threadItems(


### PR DESCRIPTION
Drag down the line-number gutter (or shift-click) to select a range and comment on it. The hunk anchor grows an optional endLine — every existing anchor is already a valid single-line range, so stored reviews need no migration. The line the composer opens on is the range's fixed anchor; the scope chip's steppers walk the free edge one line at a time, through the anchor and out the far side, every press reversible. The draft (and intent) live outside the CommentBox so the composer row can move under the range's last line without eating a half-typed comment.

A sent range comment marks its lines with a chat glyph on the first line and a quiet ink-3 spine that runs through the card row; hovering the card lights the whole range. Range labels flow through thread heads, the rail, Finish review, and the agent prompt (path:12-20 (new side)); parseAnchor round-trips endLine and collapses degenerate spans.

Out of scope, deliberately: agent-authored ranges (--lines) and cross-side ranges in split view.
