### PR TITLE
docs: teach multi-line comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,9 +109,9 @@ The judgement stays yours. You just stop reading alone.
 
 **A thread is a decision**
 
-Each comment is one small call: change this, explain that, leave it alone. Mark it a Change
-or a Question and the agent is told which. The review is the sum of those decisions, not a
-verdict at the end.
+Each comment is one small call: change this, explain that, leave it alone. Drop it on a
+line or drag down the gutter for a range of them. Mark it a Change or a Question and the
+agent is told which. The review is the sum of those decisions, not a verdict at the end.
 
 </td>
 <td width="50%">

--- a/docs/guide/the-loop.md
+++ b/docs/guide/the-loop.md
@@ -32,10 +32,23 @@ The agent keeps writing; new files appear, stats tick, fresh hunks pulse. If
 something you already marked viewed changes, the mark comes off and the hunk
 says *changed since you read it*.
 
-## You comment: on a line, a file, or the whole changeset
+## You comment: on a line, a range of lines, a file, or the whole changeset
 
 Every comment is a thread, marked **Change** (edit the code) or **Question**
 (answer it, touch nothing).
+
+For more than one line, drag down the line numbers and release — the composer
+opens on the range. The line you started on is the range's **anchor**; the
+▲/▼ on the composer's chip walk the other edge one line at a time, up past the
+anchor or down through it and out the other side, and every press has an exact
+inverse — no selection is ever lost to a stray click. Shift-click puts that
+edge on any line directly. Your draft is held outside the composer, so
+reshaping the range mid-sentence never eats what you typed.
+
+A sent range comment stays legible in the diff: a small glyph on its first
+line, a thin spine down to its card, and the whole range lights up when you
+hover the card. The agent receives the range too —
+`src/db.ts:214-231 (new side)`, not just one line.
 
 - **Send to agent** delivers it now.
 - **Add comment** queues it.

--- a/docs/reference/keyboard-shortcuts.md
+++ b/docs/reference/keyboard-shortcuts.md
@@ -37,3 +37,9 @@ two different claims, and Finish review sends both.
 `⌘↵` **adds** the comment and leaves it in your review; it does not send it to
 the agent. Sending is **Send to agent** on a single thread, or **Finish review**
 for the batch.
+
+Multi-line comments are mouse grammar rather than keys: **drag** down the line
+numbers to select a range, **shift-click** a line number to move the open
+composer's free edge there, and the **▲/▼** on the composer's chip walk that
+edge one line at a time — through the starting line and out the other side, so
+a run of ▼ reads "this line as top, N lines down". Every press is reversible.

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -41,6 +41,9 @@ The bar above the diff counts down as you mark files reviewed: `12 left`, then
 `all reviewed`.
 
 To comment, press `c` on a hunk, or hover any line and click the button in the gutter.
+For several lines at once, drag down the line numbers and release — the composer opens
+on the range, and the ▲/▼ on its chip (or a shift-click) adjust the edge one line at a
+time without losing what you've typed.
 
 <video class="clip clip-light" src="./assets/t3-comment.mp4" muted loop playsinline width="1440" height="1102" poster="./assets/t3-comment-poster.jpg" preload="none"
   aria-label="A comment composer opens on a line of the diff, the Question chip is selected, and a real question is typed before Add comment."></video>

--- a/src/ui/components/Shortcuts.test.tsx
+++ b/src/ui/components/Shortcuts.test.tsx
@@ -22,6 +22,8 @@ describe('Shortcuts', () => {
       'o',
       'b',
       'c',
+      'drag ↓',
+      '⇧ click',
       '⌘↵',
       'esc',
       '?',

--- a/src/ui/components/Shortcuts.tsx
+++ b/src/ui/components/Shortcuts.tsx
@@ -26,6 +26,8 @@ const GROUPS: { name: string; keys: [string, string][] }[] = [
     name: 'Comment',
     keys: [
       ['c', 'Comment on this hunk'],
+      ['drag ↓', 'Comment on a range of lines'],
+      ['⇧ click', 'Move the range’s edge to a line'],
       ['⌘↵', 'Add the comment'],
       ['esc', 'Close / cancel'],
       ['?', 'This sheet'],


### PR DESCRIPTION
The feature landed in #29 with nothing telling a reviewer it exists. Now the docs do: the loop guide gets the full model (drag, the fixed anchor, the edge-walking steppers, the at-rest glyph and spine, what the agent receives), the tutorial and README get a sentence each, the shortcuts reference gets the mouse grammar, and the in-app ? sheet lists drag and shift-click beside c — so the app teaches it where the reviewer already looks.
