### PR TITLE
feat: anchored-line fidelity and a live agent activity chip

### DIFF
--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -36,12 +36,12 @@ import {
   buildCoalescedPrompt,
   buildFinishPrompt,
   buildThreadPrompt,
+  captureAnchor,
   INSTALL_SKILL,
   IS_DEV,
   JOIN_PROMPT,
   nextStepFor,
   type PromptContext,
-  snapshotHunk,
 } from './prompt.js'
 import { parseAnchor, ReviewStore } from './review.js'
 import { ChangesetStore } from './store.js'
@@ -229,16 +229,14 @@ export function createApp(
           ? body.line
           : null
       const anchor = agentAnchor(file, line)
-      const codeContext =
-        anchor.kind === 'hunk' && store ? snapshotHunk(store.get(), anchor.hunkId) : null
-      return c.json(review.createThread(anchor, text, codeContext, undefined, 'agent'))
+      const capture = store ? captureAnchor(store.get(), anchor) : null
+      return c.json(review.createThread(anchor, text, capture, undefined, 'agent'))
     }
     const anchor = parseAnchor(body?.anchor)
     if (!anchor) return c.json({ error: 'need {anchor, text}' }, 400)
     const intent = THREAD_INTENTS.includes(body?.intent) ? (body.intent as ThreadIntent) : undefined
-    const codeContext =
-      anchor.kind === 'hunk' && store ? snapshotHunk(store.get(), anchor.hunkId) : null
-    return c.json(review.createThread(anchor, text, codeContext, intent))
+    const capture = store ? captureAnchor(store.get(), anchor) : null
+    return c.json(review.createThread(anchor, text, capture, intent))
   })
 
   app.post('/api/review/threads/:id/messages', async (c) => {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -497,7 +497,13 @@ export function createApp(
     }
     if (snapshot.kind === 'finish') {
       const batch = activeThreads(threads)
-      const actionable = batch.filter((t) => t.state === 'sent').map((t) => t.id)
+      // Owed a reply = the reviewer spoke last. A thread already ending with the
+      // agent's answer still rides the prompt as context, but putting it back on
+      // the reply clock brands the agent "no answer" for obeying the prompt's own
+      // "don't reply again" instruction.
+      const actionable = batch
+        .filter((t) => t.state === 'sent' && t.messages.at(-1)?.author === 'reviewer')
+        .map((t) => t.id)
       return {
         status: 'feedback' as const,
         kind: 'finish' as const,

--- a/src/server/prompt.test.ts
+++ b/src/server/prompt.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs'
 import { dirname, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import type { ReviewThread } from '../shared/review.js'
+import type { Anchor, ReviewThread } from '../shared/review.js'
 import type { Changeset } from '../shared/types.js'
 import {
   ACK_NEXT_STEP,
@@ -13,6 +13,7 @@ import {
   buildThreadPrompt,
   CLI,
   CLI_COMMANDS,
+  captureAnchor,
   guideInherit,
   guideNudge,
   INSTALL_SKILL,
@@ -407,6 +408,212 @@ describe('reviewer intent', () => {
     const prompt = buildThreadPrompt(thread(), ctx)
     expect(prompt).toContain('### Thread 1 — src/a.ts:12 (new side)')
     expect(prompt).toContain('Unlabeled threads: judge from the text')
+  })
+})
+
+describe('captureAnchor (what a new thread freezes)', () => {
+  const hunk = {
+    id: 'h1',
+    path: 'src/a.ts',
+    oldStart: 10,
+    newStart: 10,
+    lines: [
+      { kind: 'context' as const, oldNo: 10, newNo: 10, text: 'function total() {' },
+      { kind: 'del' as const, oldNo: 11, newNo: null, text: '  return sum' },
+      { kind: 'add' as const, oldNo: null, newNo: 11, text: '  const t = round(sum)' },
+      { kind: 'add' as const, oldNo: null, newNo: 12, text: '  return t' },
+      { kind: 'context' as const, oldNo: 12, newNo: 13, text: '}' },
+    ],
+  }
+  const withHunk = changeset({
+    files: [
+      {
+        path: 'src/a.ts',
+        oldPath: null,
+        status: 'modified',
+        kind: 'text',
+        staged: false,
+        hunks: [hunk],
+      },
+    ],
+  })
+  const anchor = (over: Partial<Extract<Anchor, { kind: 'hunk' }>> = {}): Anchor => ({
+    kind: 'hunk',
+    hunkId: 'h1',
+    path: 'src/a.ts',
+    side: 'new',
+    line: 11,
+    ...over,
+  })
+
+  it('freezes the whole hunk plus where the anchored line sits in it', () => {
+    const capture = captureAnchor(withHunk, anchor())
+    expect(capture?.codeContext).toBe(
+      ' function total() {\n-  return sum\n+  const t = round(sum)\n+  return t\n }',
+    )
+    expect(capture?.anchored).toEqual({ start: 2, end: 2, text: '+  const t = round(sum)' })
+  })
+
+  it('a range covers every row between its lines', () => {
+    const capture = captureAnchor(withHunk, anchor({ endLine: 12 }))
+    expect(capture?.anchored).toEqual({
+      start: 2,
+      end: 3,
+      text: '+  const t = round(sum)\n+  return t',
+    })
+  })
+
+  it('old-side anchors resolve against the old numbering — deleted lines included', () => {
+    const capture = captureAnchor(withHunk, anchor({ side: 'old' }))
+    expect(capture?.anchored).toEqual({ start: 1, end: 1, text: '-  return sum' })
+  })
+
+  it('a line the hunk does not carry still freezes the snapshot, just unmarked', () => {
+    const capture = captureAnchor(withHunk, anchor({ line: 99 }))
+    expect(capture?.codeContext).toContain('round(sum)')
+    expect(capture?.anchored).toBeUndefined()
+  })
+
+  it('non-hunk anchors and vanished hunks capture nothing', () => {
+    expect(captureAnchor(withHunk, { kind: 'file', path: 'src/a.ts' })).toBeNull()
+    expect(captureAnchor(withHunk, anchor({ hunkId: 'gone' }))).toBeNull()
+  })
+
+  it('caps the frozen text of a huge range, keeping its head', () => {
+    const lines = Array.from({ length: 30 }, (_, i) => ({
+      kind: 'add' as const,
+      oldNo: null,
+      newNo: i + 1,
+      text: `line ${i + 1}`,
+    }))
+    const big = changeset({
+      files: [
+        {
+          path: 'src/a.ts',
+          oldPath: null,
+          status: 'modified',
+          kind: 'text',
+          staged: false,
+          hunks: [{ id: 'h1', path: 'src/a.ts', oldStart: 1, newStart: 1, lines }],
+        },
+      ],
+    })
+    const capture = captureAnchor(big, anchor({ line: 1, endLine: 30 }))
+    expect(capture?.anchored?.start).toBe(0)
+    expect(capture?.anchored?.end).toBe(29)
+    expect(capture?.anchored?.text.split('\n')).toHaveLength(10)
+  })
+})
+
+describe('anchored threads in the prompt (the agent must find the commented code)', () => {
+  const anchored = { start: 0, end: 0, text: '+const x = 1' }
+
+  it('quotes the anchored line in the heading — the identifier that survives code movement', () => {
+    const prompt = buildThreadPrompt(thread({ anchored }), ctx)
+    expect(prompt).toContain('### Thread 1 — src/a.ts:12 (new side) — "const x = 1"')
+  })
+
+  it('a range heading quotes its first line as a start marker', () => {
+    const prompt = buildThreadPrompt(
+      thread({
+        anchor: {
+          kind: 'hunk',
+          hunkId: 'h1',
+          path: 'src/a.ts',
+          side: 'new',
+          line: 12,
+          endLine: 14,
+        },
+        anchored,
+      }),
+      ctx,
+    )
+    expect(prompt).toContain('src/a.ts:12-14 (new side) — starts at: "const x = 1"')
+  })
+
+  it('a range opening on a blank line quotes its first line with content', () => {
+    const prompt = buildThreadPrompt(
+      thread({
+        anchor: {
+          kind: 'hunk',
+          hunkId: 'h1',
+          path: 'src/a.ts',
+          side: 'new',
+          line: 12,
+          endLine: 14,
+        },
+        anchored: { start: 0, end: 2, text: '+\n+  \n+const y = 2' },
+      }),
+      ctx,
+    )
+    expect(prompt).toContain('src/a.ts:12-14 (new side) — starts at: "const y = 2"')
+  })
+
+  it('an all-blank anchored range keeps the plain heading', () => {
+    const prompt = buildThreadPrompt(thread({ anchored: { start: 0, end: 0, text: '+  ' } }), ctx)
+    expect(prompt).toContain('### Thread 1 — src/a.ts:12 (new side)\n')
+  })
+
+  it('marks the commented lines inside the snapshot', () => {
+    const prompt = buildThreadPrompt(
+      thread({
+        codeContext: ' before\n+const x = 1\n after',
+        anchored: { start: 1, end: 1, text: '+const x = 1' },
+      }),
+      ctx,
+    )
+    expect(prompt).toContain('The commented change (`>` marks the commented lines):')
+    expect(prompt).toContain('\n>+const x = 1\n')
+    expect(prompt).toContain('\n before\n')
+  })
+
+  it('windows a long snapshot around the commented line, not the hunk head', () => {
+    const long = Array.from({ length: 40 }, (_, i) => `+line ${i}`).join('\n')
+    const prompt = buildThreadPrompt(
+      thread({ codeContext: long, anchored: { start: 30, end: 30, text: '+line 30' } }),
+      ctx,
+    )
+    expect(prompt).toContain('>+line 30')
+    expect(prompt).not.toContain('+line 10\n')
+    expect(prompt).toContain(
+      '(windowed to the commented lines — 15 more snapshot lines around them; read the current `src/a.ts` for the full change)',
+    )
+  })
+
+  it('warns when the code moved under the comment', () => {
+    const prompt = buildThreadPrompt(thread({ anchored, codeChanged: true }), ctx)
+    expect(prompt).toContain('its line numbers are stale')
+  })
+
+  it('a fresh new-side thread carries no warning', () => {
+    const prompt = buildThreadPrompt(thread({ anchored }), ctx)
+    expect(prompt).not.toContain('line numbers are stale')
+    expect(prompt).not.toContain('removed code')
+  })
+
+  it('old-side anchors say the code is the old version, not the current file', () => {
+    const prompt = buildThreadPrompt(
+      thread({
+        anchor: { kind: 'hunk', hunkId: 'h1', path: 'src/a.ts', side: 'old', line: 12 },
+        codeContext: '-const x = 1',
+        anchored: { start: 0, end: 0, text: '-const x = 1' },
+      }),
+      ctx,
+    )
+    expect(prompt).toContain('This comments on removed code')
+  })
+
+  it('a follow-up after resolve still shows the commented lines — the snapshot is gone', () => {
+    const prompt = buildThreadPrompt(thread({ codeContext: null, anchored }), ctx)
+    expect(prompt).toContain('The commented lines, as they were when the comment was written:')
+    expect(prompt).toContain('+const x = 1')
+  })
+
+  it('threads from before anchoring existed render exactly as they used to', () => {
+    const prompt = buildThreadPrompt(thread(), ctx)
+    expect(prompt).toContain('The commented change:')
+    expect(prompt).not.toContain('marks the commented lines')
+    expect(prompt).not.toContain(' — "')
   })
 })
 

--- a/src/server/prompt.ts
+++ b/src/server/prompt.ts
@@ -1,22 +1,48 @@
 import { fileURLToPath } from 'node:url'
 import {
+  type Anchor,
   type Coverage,
   describeAnchor,
   type ReviewThread,
   startedByAgent,
   THREAD_INTENTS,
+  type ThreadCapture,
   type ThreadIntent,
 } from '../shared/review.js'
-import type { Changeset, FileChange } from '../shared/types.js'
+import type { Changeset, FileChange, Hunk } from '../shared/types.js'
 
-export function snapshotHunk(changeset: Changeset, hunkId: string): string | null {
+/** A comment can anchor to a long range; the frozen text keeps its head. */
+const ANCHORED_TEXT_CAP = 10
+
+function findHunk(changeset: Changeset, hunkId: string): Hunk | null {
   for (const file of changeset.files) {
     const hunk = file.hunks.find((h) => h.id === hunkId)
-    if (!hunk) continue
-    const marker = { add: '+', del: '-', context: ' ' } as const
-    return hunk.lines.map((l) => marker[l.kind] + l.text).join('\n')
+    if (hunk) return hunk
   }
   return null
+}
+
+/**
+ * Freeze what a new thread anchors to: the whole hunk as a diff snapshot, plus
+ * — for the anchored line range — where those rows sit in it and their text.
+ * Null for non-hunk anchors and for a hunk the changeset no longer has.
+ */
+export function captureAnchor(changeset: Changeset, anchor: Anchor): ThreadCapture | null {
+  if (anchor.kind !== 'hunk') return null
+  const hunk = findHunk(changeset, anchor.hunkId)
+  if (!hunk) return null
+  const marker = { add: '+', del: '-', context: ' ' } as const
+  const rows = hunk.lines.map((l) => marker[l.kind] + l.text)
+  const codeContext = rows.join('\n')
+  const last = anchor.endLine ?? anchor.line
+  const covered = hunk.lines
+    .map((l, row) => ({ no: anchor.side === 'old' ? l.oldNo : l.newNo, row }))
+    .filter((r) => r.no !== null && r.no >= anchor.line && r.no <= last)
+  if (covered.length === 0) return { codeContext }
+  const start = covered[0]!.row
+  const end = covered.at(-1)!.row
+  const text = rows.slice(start, Math.min(end + 1, start + ANCHORED_TEXT_CAP)).join('\n')
+  return { codeContext, anchored: { start, end, text } }
 }
 
 /** Scoped, because the bare `diffo` name on npm belongs to an unrelated package.
@@ -281,6 +307,104 @@ export function siblingLines(siblings: ReviewThread[]): string | null {
 
 const SNAPSHOT_LINE_CAP = 25
 
+/** The heading's movement-proof identifier: the first anchored line's text,
+ * stripped of its diff marker. The line numbers in `describeAnchor` go stale
+ * the moment the code moves; this text is what the agent can still search for. */
+function anchorQuote(thread: ReviewThread): string {
+  // The first line with content — a range can open on a blank line.
+  const first = thread.anchored?.text
+    .split('\n')
+    .map((line) => line.slice(1).trim())
+    .find((line) => line !== '')
+    ?.slice(0, 80)
+  if (!first) return ''
+  const range = thread.anchor.kind === 'hunk' && thread.anchor.endLine !== undefined
+  return range ? ` — starts at: "${first}"` : ` — "${first}"`
+}
+
+/** When `path:line` must not be trusted against the working tree: an old-side
+ * anchor never matches it, and a rotated hunk means the code moved under the
+ * numbers. At most one note — removed code can't also have "moved". */
+function anchorNote(thread: ReviewThread): string[] {
+  if (thread.anchor.kind !== 'hunk') return []
+  if (thread.anchor.side === 'old') {
+    return [
+      'This comments on removed code — the anchored lines are the old version, not the current file.',
+    ]
+  }
+  if (thread.codeChanged) {
+    return [
+      'The code under this comment changed after the comment was written — its line numbers are stale. Find the code by its anchored lines, not by number.',
+    ]
+  }
+  return []
+}
+
+/** The `[from, to)` slice of the snapshot to show: the anchored rows centered
+ * inside the cap. A range longer than the cap keeps its head. */
+function snapshotWindow(
+  total: number,
+  anchored: { start: number; end: number },
+): { from: number; to: number } {
+  const size = Math.min(total, SNAPSHOT_LINE_CAP)
+  const span = anchored.end - anchored.start + 1
+  const pad = Math.floor(Math.max(0, size - span) / 2)
+  const from = Math.min(Math.max(0, anchored.start - pad), total - size)
+  return { from, to: from + size }
+}
+
+/** The snapshot as the agent sees it: windowed on the anchored rows, each of
+ * them marked with `>`. Threads from before `anchored` existed keep the old
+ * head-of-hunk window. */
+function snapshotBlock(thread: ReviewThread): string[] {
+  const { codeContext, anchored } = thread
+  if (!codeContext) {
+    // The snapshot is gone (dropped on resolve) but the anchored text survives —
+    // without this block a follow-up ships nothing but a stale line number.
+    if (!anchored) return []
+    const shown = anchored.text.split('\n')
+    const cut = anchored.end - anchored.start + 1 - shown.length
+    return [
+      'The commented lines, as they were when the comment was written:',
+      '```diff',
+      ...shown,
+      '```',
+      ...(cut > 0 ? [`(… and ${cut} more commented lines)`] : []),
+    ]
+  }
+  const lines = codeContext.split('\n')
+  const where = thread.anchor.kind === 'changeset' ? 'the file' : `\`${thread.anchor.path}\``
+  if (!anchored) {
+    return [
+      'The commented change:',
+      '```diff',
+      ...lines.slice(0, SNAPSHOT_LINE_CAP),
+      '```',
+      ...(lines.length > SNAPSHOT_LINE_CAP
+        ? [
+            `(… and ${lines.length - SNAPSHOT_LINE_CAP} more snapshot lines — read the current ${where} instead)`,
+          ]
+        : []),
+    ]
+  }
+  const { from, to } = snapshotWindow(lines.length, anchored)
+  const shown = lines
+    .slice(from, to)
+    .map((line, i) => (from + i >= anchored.start && from + i <= anchored.end ? `>${line}` : line))
+  const cut = lines.length - (to - from)
+  return [
+    'The commented change (`>` marks the commented lines):',
+    '```diff',
+    ...shown,
+    '```',
+    ...(cut > 0
+      ? [
+          `(windowed to the commented lines — ${cut} more snapshot lines around them; read the current ${where} for the full change)`,
+        ]
+      : []),
+  ]
+}
+
 function threadBlock(thread: ReviewThread, index: number): string {
   // A thread the agent itself started reads differently: the reviewer is
   // responding to something the agent said, not filing new feedback.
@@ -292,25 +416,14 @@ function threadBlock(thread: ReviewThread, index: number): string {
         ? ` [${INTENT_LABEL[thread.intent]}]`
         : ''
   const again = thread.unanswered ? ' — YOU NEVER ANSWERED THIS' : ''
-  const parts = [
-    `### Thread ${index + 1}${label} — ${describeAnchor(thread.anchor)}${again}`,
+  return [
+    `### Thread ${index + 1}${label} — ${describeAnchor(thread.anchor)}${anchorQuote(thread)}${again}`,
     `id: ${thread.id}`,
-  ]
-  if (thread.codeContext) {
-    const lines = thread.codeContext.split('\n')
-    parts.push('The commented change:', '```diff', ...lines.slice(0, SNAPSHOT_LINE_CAP), '```')
-    if (lines.length > SNAPSHOT_LINE_CAP) {
-      const where = thread.anchor.kind === 'changeset' ? 'the file' : `\`${thread.anchor.path}\``
-      parts.push(
-        `(… and ${lines.length - SNAPSHOT_LINE_CAP} more snapshot lines — read the current ${where} instead)`,
-      )
-    }
-  }
-  parts.push(
+    ...anchorNote(thread),
+    ...snapshotBlock(thread),
     'Messages:',
     ...thread.messages.map((m) => `- ${m.author}: ${m.text.replace(/\n/g, '\n  ')}`),
-  )
-  return parts.join('\n')
+  ].join('\n')
 }
 
 export function buildThreadPrompt(thread: ReviewThread, ctx: PromptContext): string {

--- a/src/server/review-api.test.ts
+++ b/src/server/review-api.test.ts
@@ -443,6 +443,33 @@ describe('review API', () => {
     expect(queue.take()).toBeNull()
   })
 
+  it('finish never re-opens the reply clock on a thread the agent already answered', async () => {
+    const { app } = setup()
+    const ids: string[] = []
+    for (const text of ['answered before finish', 'still waiting']) {
+      const res = await post(app, '/api/review/threads', { anchor: { kind: 'changeset' }, text })
+      ids.push(((await res.json()) as ReviewThread).id)
+      await post(app, `/api/review/threads/${ids.at(-1)}/send`)
+    }
+    // The agent picks both up and answers the first — its reply is the last word there.
+    await pollResult(await app.request('/api/agent/poll', { headers: { 'x-diffo-agent': 'cli' } }))
+    await post(app, `/api/review/threads/${ids[0]}/messages`, {
+      author: 'agent',
+      text: 'done — see the thread',
+    })
+
+    await post(app, '/api/review/finish', {
+      coverage: { viewedHunks: 1, totalHunks: 1, skippedFiles: [] },
+    })
+    const payload = await pollResult(
+      await app.request('/api/agent/poll', { headers: { 'x-diffo-agent': 'cli' } }),
+    )
+    expect(payload.kind).toBe('finish')
+    // Both threads ride the prompt for context, but only the unanswered one is owed.
+    expect(payload.threadIds).toEqual([ids[1]])
+    expect(payload.prompt).toContain('answered before finish')
+  })
+
   it('review endpoints 503 without a review store', async () => {
     const app = createApp({ root: '/x', spec: { kind: 'working-tree' }, clientDir: '/nope' })
     expect((await app.request('/api/review')).status).toBe(503)

--- a/src/server/review.test.ts
+++ b/src/server/review.test.ts
@@ -47,7 +47,7 @@ describe('ReviewStore', () => {
     const root = tempRoot()
     const store = makeStore(root)
 
-    const thread = store.createThread(hunkAnchor(), 'rename this', '+const x = 1')
+    const thread = store.createThread(hunkAnchor(), 'rename this', { codeContext: '+const x = 1' })
     expect(thread.state).toBe('open')
     expect(thread.messages).toHaveLength(1)
     expect(thread.messages[0]!.author).toBe('reviewer')
@@ -303,13 +303,19 @@ describe('ReviewStore', () => {
     expect('unanswered' in store.get().threads[0]!).toBe(false)
   })
 
-  it('resolving sheds the frozen diff — the heaviest thing in the store', () => {
+  it('resolving sheds the frozen diff but keeps the anchored lines — a follow-up needs them', () => {
     const store = makeStore(tempRoot())
-    const thread = store.createThread(hunkAnchor('h1'), 'why this?', '+ const a = 1\n- const a = 2')
+    const anchored = { start: 0, end: 0, text: '+ const a = 1' }
+    const thread = store.createThread(hunkAnchor('h1'), 'why this?', {
+      codeContext: '+ const a = 1\n- const a = 2',
+      anchored,
+    })
     expect(store.get().threads[0]!.codeContext).not.toBeNull()
+    expect(store.get().threads[0]!.anchored).toEqual(anchored)
 
     store.setState(thread.id, 'resolved')
     expect(store.get().threads[0]!.codeContext).toBeNull()
+    expect(store.get().threads[0]!.anchored).toEqual(anchored)
     expect(store.get().threads[0]!.messages).toHaveLength(1)
   })
 
@@ -398,6 +404,34 @@ describe('parseReview', () => {
     for (const bad of [4, 3, 4.5, '9', null]) {
       const anchor = parseReview(stored(bad))!.threads[0]!.anchor
       expect(anchor).toEqual({ kind: 'hunk', hunkId: 'h', path: 'a.ts', side: 'new', line: 4 })
+    }
+  })
+
+  it('anchored lines survive the round trip; a malformed record is dropped, not fatal', () => {
+    const stored = (anchored: unknown) =>
+      JSON.stringify({
+        threads: [
+          {
+            id: 't',
+            state: 'open',
+            anchor: { kind: 'hunk', hunkId: 'h', path: 'a.ts', side: 'new', line: 4 },
+            messages: [{ author: 'reviewer', text: 'hi' }],
+            anchored,
+          },
+        ],
+      })
+    const good = { start: 1, end: 2, text: '+a\n+b' }
+    expect(parseReview(stored(good))!.threads[0]!.anchored).toEqual(good)
+    for (const bad of [
+      { start: -1, end: 2, text: 'x' },
+      { start: 3, end: 2, text: 'x' },
+      { start: 0.5, end: 2, text: 'x' },
+      { start: 0, end: 1 },
+      'nope',
+    ]) {
+      const thread = parseReview(stored(bad))!.threads[0]!
+      expect(thread.id).toBe('t')
+      expect(thread.anchored).toBeUndefined()
     }
   })
 

--- a/src/server/review.ts
+++ b/src/server/review.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto'
 import { resolve } from 'node:path'
 import {
   type Anchor,
+  type AnchoredLines,
   type Author,
   type Coverage,
   EMPTY_REVIEW,
@@ -13,6 +14,7 @@ import {
   type ReviewThread,
   type ReviewVerdict,
   THREAD_INTENTS,
+  type ThreadCapture,
   type ThreadIntent,
   type ThreadState,
 } from '../shared/review.js'
@@ -75,7 +77,7 @@ export class ReviewStore {
   createThread(
     anchor: Anchor,
     text: string,
-    codeContext: string | null,
+    capture: ThreadCapture | null,
     intent?: ThreadIntent,
     author: Author = 'reviewer',
   ): ReviewThread {
@@ -85,7 +87,8 @@ export class ReviewStore {
       anchor,
       state: 'open',
       ...(intent ? { intent } : {}),
-      codeContext,
+      codeContext: capture?.codeContext ?? null,
+      ...(capture?.anchored ? { anchored: capture.anchored } : {}),
       codeChanged: false,
       messages: [{ id: randomUUID(), author, text, at: now }],
       createdAt: now,
@@ -213,7 +216,9 @@ export class ReviewStore {
       ...(state === 'sent' && !thread.sentAt ? { sentAt: new Date().toISOString() } : {}),
       // A settled thread drops its frozen diff: the snapshot keeps the thread legible
       // while the code moves underneath it, and it is the heaviest thing in the store
-      // (66% of the review row). The messages stay. Reopening does not bring it back.
+      // (66% of the review row). The messages stay, and so does `anchored` — it is
+      // small, and a follow-up on this thread has nothing else to point at the code.
+      // Reopening does not bring the snapshot back.
       ...(state === 'resolved' ? { codeContext: null } : {}),
     }))
   }
@@ -510,12 +515,26 @@ export function parseAnchor(value: unknown): Anchor | null {
   return anchor.kind === 'changeset' ? { kind: 'changeset' } : null
 }
 
+/** Dropped when malformed — the thread is still fine without it. */
+function normalizeAnchored(value: unknown): AnchoredLines | null {
+  if (typeof value !== 'object' || value === null) return null
+  const a = value as Record<string, unknown>
+  if (typeof a.start !== 'number' || typeof a.end !== 'number' || typeof a.text !== 'string') {
+    return null
+  }
+  if (!Number.isInteger(a.start) || !Number.isInteger(a.end) || a.start < 0 || a.end < a.start) {
+    return null
+  }
+  return { start: a.start, end: a.end, text: a.text }
+}
+
 function normalizeThread(value: unknown, now: string): ReviewThread | null {
   if (typeof value !== 'object' || value === null) return null
   const t = value as Record<string, unknown>
   if (typeof t.id !== 'string' || !STATES.includes(t.state as ThreadState)) return null
   const anchor = parseAnchor(t.anchor)
   if (!anchor) return null
+  const anchored = normalizeAnchored(t.anchored)
   if (!Array.isArray(t.messages)) return null
   const messages: ReviewMessage[] = []
   for (const m of t.messages) {
@@ -539,6 +558,7 @@ function normalizeThread(value: unknown, now: string): ReviewThread | null {
       ? { intent: t.intent as ThreadIntent }
       : {}),
     codeContext: typeof t.codeContext === 'string' ? t.codeContext : null,
+    ...(anchored ? { anchored } : {}),
     codeChanged: t.codeChanged === true,
     ...(t.unanswered === true ? { unanswered: true } : {}),
     ...(t.closingNote === true ? { closingNote: true as const } : {}),

--- a/src/shared/review.ts
+++ b/src/shared/review.ts
@@ -22,6 +22,25 @@ export type Anchor =
 
 export type Author = 'reviewer' | 'agent'
 
+/** The exact lines a hunk anchor covers, frozen at creation: where they sit
+ * inside `codeContext` (0-based row indices, inclusive) and their text
+ * (`+`/`-`/` `-prefixed like the snapshot, capped). The text outlives the
+ * snapshot — `codeContext` is dropped on resolve, and once the code moves the
+ * anchor's line numbers go stale, so this text is how a later follow-up still
+ * identifies what the comment was about. */
+export interface AnchoredLines {
+  start: number
+  end: number
+  text: string
+}
+
+/** What a new thread freezes about the code it anchors to. `anchored` is absent
+ * for pre-range snapshots and for anchors whose lines fell outside the hunk. */
+export interface ThreadCapture {
+  codeContext: string
+  anchored?: AnchoredLines
+}
+
 export interface ReviewMessage {
   id: string
   author: Author
@@ -36,6 +55,8 @@ export interface ReviewThread {
   state: ThreadState
   intent?: ThreadIntent
   codeContext: string | null
+  /** See {@link AnchoredLines}. Absent on threads created before it existed. */
+  anchored?: AnchoredLines
   /** The anchored hunk no longer exists in the current changeset (its
    * content-addressed ID rotated). `sent` threads become `addressed` instead. */
   codeChanged: boolean

--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -40,9 +40,11 @@ import { partitionThreads, threadsByFile } from './reviewPlacement.js'
 import { computeSinceLastReview } from './sinceLastReview.js'
 import { useTheme } from './theme.js'
 import {
+  agentActivity,
   byFile,
   isUnsent,
   type PanelTab,
+  shortAnchor,
   type ThreadItem,
   threadItems,
   unsettledCount,
@@ -159,6 +161,34 @@ function useLiveUpdates(): {
     return () => source.close()
   }, [client])
   return { presence, reason, since, workingOn, queuedOn, answeredOn }
+}
+
+/**
+ * The most recent answer's anchor, at chip length. Kept between replies so the
+ * chip has something truthful to say in the gap after one comment settles and
+ * before the agent picks up the next; gone when the batch resets or the agent
+ * stops working.
+ */
+function useLastAnswered(
+  items: readonly ThreadItem[],
+  answeredOn: ReadonlySet<string>,
+  presence: Presence,
+): string | null {
+  const [label, setLabel] = useState<string | null>(null)
+  const seen = useRef<ReadonlySet<string>>(NO_THREADS)
+  useEffect(() => {
+    const prev = seen.current
+    seen.current = answeredOn
+    if (presence !== 'working' || answeredOn.size === 0) {
+      setLabel(null)
+      return
+    }
+    const fresh = [...answeredOn].filter((id) => !prev.has(id))
+    if (fresh.length === 0) return
+    const item = items.find((i) => i.thread.id === fresh[fresh.length - 1])
+    if (item) setLabel(shortAnchor(item.anchor))
+  }, [items, answeredOn, presence])
+  return label
 }
 
 function useReviewActions(): ReviewActions {
@@ -313,6 +343,8 @@ function Review() {
     }),
     [batch],
   )
+  const lastAnswered = useLastAnswered(items, answeredOn, presence)
+  const activity = presence === 'working' ? agentActivity(batch.stillTo, lastAnswered) : null
   const [monitorOpen, setMonitorOpen] = useState(false)
   useEffect(() => {
     if (monitorOpen && batch.stillTo.length === 0 && batch.back.length === 0) setMonitorOpen(false)
@@ -860,6 +892,7 @@ function Review() {
         agent={{
           presence,
           since: presenceSince,
+          activity,
           onInvite: () => setInviteOpen(true),
           batch: batchForBadge,
           monitorOpen,

--- a/src/ui/components/Header.test.tsx
+++ b/src/ui/components/Header.test.tsx
@@ -195,6 +195,31 @@ describe('Header', () => {
     expect(container.querySelector('.presence')!.textContent).toContain('agent · listening')
   })
 
+  it('a working chip narrates the activity in place of the static label', () => {
+    const { rerender, container } = render(
+      <Header
+        changeset={changeset()}
+        agent={{ presence: 'working', activity: 'working on db.ts:42' }}
+      />,
+    )
+    const label = () => container.querySelector('.presence-label')!.textContent
+    expect(label()).toContain('working on db.ts:42')
+    expect(label()).not.toContain('agent · working')
+
+    // No activity to report → the label falls back to what it says today.
+    rerender(<Header changeset={changeset()} agent={{ presence: 'working', activity: null }} />)
+    expect(label()).toContain('agent · working')
+
+    // Activity is the working state's voice alone — listening never borrows it.
+    rerender(
+      <Header
+        changeset={changeset()}
+        agent={{ presence: 'listening', activity: 'working on db.ts:42' }}
+      />,
+    )
+    expect(label()).toContain('agent · listening')
+  })
+
   it('without an invite handler the waiting chip stays a plain statement', () => {
     const { container } = render(<Header changeset={changeset()} agent={{ presence: 'waiting' }} />)
     expect(container.querySelector('button.presence')).toBeNull()

--- a/src/ui/components/Header.tsx
+++ b/src/ui/components/Header.tsx
@@ -81,6 +81,7 @@ export interface AgentBatch {
 function PresenceChip({
   presence,
   since,
+  activity,
   onInvite,
   batch,
   monitorOpen = false,
@@ -89,6 +90,7 @@ function PresenceChip({
 }: {
   presence: Presence
   since?: number | null
+  activity?: string | null
   onInvite?: () => void
   batch?: AgentBatch
   monitorOpen?: boolean
@@ -123,7 +125,7 @@ function PresenceChip({
         <i />
       </span>
       <span className="presence-label">
-        {PRESENCE_LABEL[presence]}
+        {(presence === 'working' && activity) || PRESENCE_LABEL[presence]}
         {showAgo && <span className="presence-ago"> · {formatAgo(Date.now() - since)}</span>}
       </span>
     </>
@@ -178,6 +180,8 @@ function PresenceChip({
 export interface HeaderAgent {
   presence?: Presence
   since?: number | null
+  /** What the agent is doing right now — replaces the static working label. */
+  activity?: string | null
   onInvite?: () => void
   batch?: AgentBatch
   monitorOpen?: boolean
@@ -230,6 +234,7 @@ export function Header({
         <PresenceChip
           presence={agent.presence}
           since={agent.since}
+          activity={agent.activity}
           onInvite={agent.onInvite}
           batch={agent.batch}
           monitorOpen={agent.monitorOpen}

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -5161,6 +5161,14 @@ select.input {
     color var(--dur-move) var(--ease-out);
 }
 
+/* The label carries live activity ("working on db.ts:42"), and a path can be any
+   length — the chip clips it rather than squeezing the header. */
+.presence-label {
+  max-width: 34ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
 /* A lamp, for the invite modal's one-line statements. The chip in the header uses
    the meter below instead — it has three states to tell apart, not two. */
 .presence-dot {

--- a/src/ui/threads.test.ts
+++ b/src/ui/threads.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { Anchor, ReviewMessage, ReviewThread } from '../shared/review.js'
 import {
+  agentActivity,
   byFile,
   byTurn,
   holdsAttention,
   isUnsent,
+  shortAnchor,
   threadItems,
   threadOutcome,
   threadTurn,
@@ -343,5 +345,65 @@ describe('agent-voice threads', () => {
     expect(threadTurn(answered)).toBe('yours')
 
     expect(threadTurn(agentThread({ state: 'resolved' }))).toBe('resolved')
+  })
+})
+
+describe('shortAnchor', () => {
+  it('keeps the basename and the line, drops the directory', () => {
+    expect(shortAnchor('src/server/db.ts:42')).toBe('db.ts:42')
+    expect(shortAnchor('src/server/db.ts:42-45')).toBe('db.ts:42-45')
+  })
+
+  it('a file-level anchor is just the basename', () => {
+    expect(shortAnchor('src/ui/App.tsx')).toBe('App.tsx')
+  })
+
+  it('a changeset thread has no path to shorten', () => {
+    expect(shortAnchor(null)).toBe('the changeset')
+  })
+})
+
+describe('agentActivity', () => {
+  const sent = (id: string, path: string | null, working = false) =>
+    threadItems(
+      [
+        thread({
+          id,
+          state: 'sent',
+          anchor: path
+            ? ({ kind: 'hunk', hunkId: 'h', path, side: 'new', line: 42 } as Anchor)
+            : ({ kind: 'changeset' } as Anchor),
+        }),
+      ],
+      working ? new Set([id]) : new Set(),
+    )[0]!
+
+  it('names the thread the agent holds, at chip length', () => {
+    const items = [sent('t-1', 'src/server/db.ts', true), sent('t-2', 'src/ui/api.ts')]
+    expect(agentActivity(items, null)).toBe('working on db.ts:42')
+  })
+
+  it('a held changeset thread still reads as work', () => {
+    expect(agentActivity([sent('t-1', null, true)], null)).toBe('working on the changeset')
+  })
+
+  it('between replies, the last answer carries the label', () => {
+    expect(agentActivity([sent('t-2', 'src/ui/api.ts')], 'db.ts:42')).toBe('answered db.ts:42')
+  })
+
+  it('freshly delivered, before any work signal, it counts the batch', () => {
+    const items = [sent('t-1', 'src/a.ts'), sent('t-2', 'src/b.ts')]
+    expect(agentActivity(items, null)).toBe('picked up 2 comments')
+    expect(agentActivity([sent('t-1', 'src/a.ts')], null)).toBe('picked up 1 comment')
+  })
+
+  it('nothing specific to say → null, and the static label stands', () => {
+    expect(agentActivity([], null)).toBeNull()
+  })
+
+  it('current work outranks the last answer', () => {
+    expect(agentActivity([sent('t-1', 'src/ui/api.ts', true)], 'db.ts:42')).toBe(
+      'working on api.ts:42',
+    )
   })
 })

--- a/src/ui/threads.ts
+++ b/src/ui/threads.ts
@@ -136,6 +136,31 @@ export function threadItems(
   })
 }
 
+/** An anchor at chip length: the basename keeps the line number, the directory
+ * goes — the full path is one click away in the monitor. */
+export function shortAnchor(anchor: string | null): string {
+  if (anchor === null) return 'the changeset'
+  return anchor.slice(anchor.lastIndexOf('/') + 1)
+}
+
+/**
+ * The chip's one-line account of what the agent is doing right now, composed
+ * from the batch the client already tracks. Null when there is nothing more
+ * specific to say than "working".
+ */
+export function agentActivity(
+  stillTo: readonly ThreadItem[],
+  lastAnswered: string | null,
+): string | null {
+  const working = stillTo.find((i) => i.working === true)
+  if (working) return `working on ${shortAnchor(working.anchor)}`
+  if (lastAnswered !== null) return `answered ${lastAnswered}`
+  if (stillTo.length > 0) {
+    return `picked up ${stillTo.length} comment${stillTo.length === 1 ? '' : 's'}`
+  }
+  return null
+}
+
 export function byTurn(items: readonly ThreadItem[]): Map<Turn, ThreadItem[]> {
   const out = new Map<Turn, ThreadItem[]>()
   for (const turn of TURN_ORDER) {


### PR DESCRIPTION
Two strands, reviewed together in a live Diffo session:

## Anchored-line fidelity (server)
A new thread now freezes exactly what it points at: the anchored rows' position
in the hunk snapshot and their marker-prefixed text (capped at 10 lines).
- Prompt headings quote the first anchored line with content — the identifier
  that survives code movement; ranges get a "starts at:" marker.
- Snapshots are windowed around the commented lines and mark them with `>`.
- Old-side and stale-line anchors carry an explicit note so the agent never
  trusts a dead `path:line`.
- Resolve still sheds the heavy snapshot but keeps the small anchored text, so
  follow-ups on settled threads retain something to find the code by.
- Malformed stored records are dropped without losing the thread.

## Fix: false "no answer" after Finish review
Finish re-delivered threads the agent had already answered and put them back on
the reply clock, while the prompt itself said "don't reply again" — the next
poll then branded the agent "no answer — the agent moved on". The finish batch
now only owes a reply on threads whose last message is the reviewer's; answered
threads still ride the prompt as context.

## Live agent activity in the header chip
While an agent works, the presence chip narrates instead of the static
"agent · working": `picked up 5 comments` → `working on db.ts:42 · 0/5` →
`answered db.ts:42 · 1/5`. Composed entirely client-side from batch state the
presence SSE already carries — no server changes, no agent-side cost. Falls
back to the static label whenever there is nothing specific to say; long paths
ellipsize so the header never stretches.

Tests: 951/951 passing (new coverage for captureAnchor, prompt
windowing/quoting, store round-trip, the finish/poll flow end-to-end, and the
chip's label logic).