### PR TITLE
feat: give icon-only buttons real tooltips

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -957,7 +957,7 @@ function Review() {
           aria-valuemax={RAIL_MAX}
           aria-valuenow={railWidth}
           tabIndex={0}
-          title="Drag to resize · double-click (or Home) to reset"
+          data-tip="Drag to resize · double-click (or Home) to reset"
           onPointerDown={beginRailResize}
           onDoubleClick={resetRailWidth}
           onKeyDown={(e) => {

--- a/src/ui/components/AgentBanner.tsx
+++ b/src/ui/components/AgentBanner.tsx
@@ -64,6 +64,7 @@ export function AgentBanner({
       <button
         type="button"
         className="btn btn-ghost btn-icon btn-sm agent-banner-x"
+        data-tip="Dismiss"
         aria-label="dismiss"
         onClick={onClear}
       >

--- a/src/ui/components/CommentBox.tsx
+++ b/src/ui/components/CommentBox.tsx
@@ -164,7 +164,7 @@ export function CommentBox({
                     type="button"
                     className="scope-chip-step"
                     disabled={!scope.adjust.up}
-                    title="walk the range's edge one line up — the line you started on stays put"
+                    data-tip="walk the range's edge one line up — the line you started on stays put"
                     aria-label="range edge one line up"
                     onClick={scope.adjust.up}
                   >
@@ -174,7 +174,7 @@ export function CommentBox({
                     type="button"
                     className="scope-chip-step"
                     disabled={!scope.adjust.down}
-                    title="walk the range's edge one line down — the line you started on stays put"
+                    data-tip="walk the range's edge one line down — the line you started on stays put"
                     aria-label="range edge one line down"
                     onClick={scope.adjust.down}
                   >
@@ -186,6 +186,7 @@ export function CommentBox({
                 <button
                   type="button"
                   className="scope-chip-x"
+                  data-tip="Narrow the scope back"
                   aria-label="Narrow the scope back"
                   onClick={() => setWide(false)}
                 >
@@ -203,7 +204,7 @@ export function CommentBox({
         <button
           type="button"
           className="cbox-close"
-          title="Close (Esc)"
+          data-tip="Close (Esc)"
           aria-label="Close"
           onClick={onCancel}
         >
@@ -240,7 +241,7 @@ export function CommentBox({
                 key={i}
                 type="button"
                 className="cbox-mdb"
-                title={action.label}
+                data-tip={action.label}
                 aria-label={action.label}
                 onClick={() => box.current && applyToolbar(box.current, action, setText)}
               >
@@ -301,7 +302,7 @@ export function CommentBox({
           type="button"
           className="cbox-rich"
           aria-pressed={rich}
-          title="Formatting and preview"
+          data-tip="Formatting and preview"
           aria-label="Formatting and preview"
           onClick={toggleRich}
         >

--- a/src/ui/components/FinishReview.tsx
+++ b/src/ui/components/FinishReview.tsx
@@ -155,7 +155,7 @@ export function FinishReview({
           <button
             type="button"
             className="ghb"
-            title="copy the prompt without finishing"
+            data-tip="copy the prompt without finishing"
             aria-label="Copy the prompt without finishing"
             onClick={() => void copyText(preview.data!.prompt)}
           >

--- a/src/ui/components/HunkCard.tsx
+++ b/src/ui/components/HunkCard.tsx
@@ -64,7 +64,7 @@ export function GapExpanders({ gap }: { gap: GapControls }) {
         <button
           type="button"
           className="gap-btn"
-          title={`expand all (${gap.remaining} hidden ${gap.remaining === 1 ? 'line' : 'lines'})`}
+          data-tip={`expand all (${gap.remaining} hidden ${gap.remaining === 1 ? 'line' : 'lines'})`}
           aria-label={`expand all ${gap.remaining} hidden lines`}
           onClick={(e) => act(e, gap.onAll)}
         >
@@ -80,7 +80,7 @@ export function GapExpanders({ gap }: { gap: GapControls }) {
         <button
           type="button"
           className="gap-btn"
-          title={`expand down (${EXPAND_STEP} lines)`}
+          data-tip={`expand down (${EXPAND_STEP} lines)`}
           aria-label="expand down"
           onClick={(e) => act(e, gap.onDown)}
         >
@@ -91,7 +91,7 @@ export function GapExpanders({ gap }: { gap: GapControls }) {
         <button
           type="button"
           className="gap-btn"
-          title={`expand up (${EXPAND_STEP} lines)`}
+          data-tip={`expand up (${EXPAND_STEP} lines)`}
           aria-label="expand up"
           onClick={(e) => act(e, gap.onUp)}
         >
@@ -107,7 +107,7 @@ function FoldButton({ onCollapse }: { onCollapse: () => void }) {
     <button
       type="button"
       className="gap-fold"
-      title="hide expanded lines"
+      data-tip="hide expanded lines"
       aria-label="hide expanded lines"
       onClick={(e) => {
         e.stopPropagation()
@@ -316,7 +316,7 @@ function CommentButton({ onClick }: { onClick: () => void }) {
     <button
       type="button"
       className="line-comment-btn"
-      title="comment on this line — drag down to take more lines"
+      data-tip="comment on this line — drag down to take more lines"
       aria-label="comment on this line, or drag down to comment on a range"
       onClick={(e) => {
         e.stopPropagation()

--- a/src/ui/components/Menu.tsx
+++ b/src/ui/components/Menu.tsx
@@ -49,6 +49,7 @@ export function Menu({
         type="button"
         className={triggerClassName}
         aria-label={label}
+        data-tip={open ? undefined : label}
         aria-haspopup="menu"
         aria-expanded={open}
         onClick={(e) => {

--- a/src/ui/components/Modal.tsx
+++ b/src/ui/components/Modal.tsx
@@ -96,7 +96,13 @@ export function Modal({
         <div className="modal-head">
           <h3>{title}</h3>
           {badge}
-          <button type="button" className="ghb" aria-label="Close" title="Close" onClick={onClose}>
+          <button
+            type="button"
+            className="ghb"
+            aria-label="Close"
+            data-tip="Close"
+            onClick={onClose}
+          >
             <Icon name="x" size="sm" />
           </button>
         </div>

--- a/src/ui/components/Nav.tsx
+++ b/src/ui/components/Nav.tsx
@@ -123,7 +123,7 @@ function FileRow({
         role="checkbox"
         aria-checked={done}
         aria-label={`${done ? 'Mark not reviewed' : 'Mark reviewed'}: ${file.path}`}
-        title={done ? 'Mark not reviewed' : 'Mark reviewed'}
+        data-tip={done ? 'Mark not reviewed' : 'Mark reviewed'}
         disabled={!onToggleViewed}
         onClick={onToggleViewed}
       >
@@ -188,7 +188,7 @@ function FileRow({
             <button
               type="button"
               className="row-act"
-              title="Comment on this file"
+              data-tip="Comment on this file"
               aria-label="Comment on this file"
               onClick={onAsk}
             >
@@ -323,7 +323,7 @@ export function Nav({
               ? `Mark ${dir.name} not reviewed`
               : `Mark ${markable.length} file${markable.length === 1 ? '' : 's'} in ${dir.name} reviewed`
           }
-          title={
+          data-tip={
             allDone
               ? `Mark ${inside.length} file${inside.length === 1 ? '' : 's'} not reviewed`
               : `Mark ${markable.length} file${markable.length === 1 ? '' : 's'} reviewed`
@@ -389,7 +389,7 @@ export function Nav({
             <button
               type="button"
               className="sb-clear"
-              title="Clear filter"
+              data-tip="Clear filter"
               aria-label="Clear filter"
               onClick={() => {
                 setQuery('')

--- a/src/ui/components/PaneBar.tsx
+++ b/src/ui/components/PaneBar.tsx
@@ -55,7 +55,7 @@ export function PaneBar({
           type="button"
           className="pane-icon pane-nav"
           onClick={onToggleNav}
-          title={`${navHidden ? 'Show' : 'Hide'} the file list (b)`}
+          data-tip={`${navHidden ? 'Show' : 'Hide'} the file list (b)`}
           aria-label={`${navHidden ? 'Show' : 'Hide'} the file list`}
           aria-pressed={!navHidden}
         >
@@ -115,7 +115,7 @@ export function PaneBar({
           type="button"
           className="pane-icon"
           aria-pressed={viewMode === 'unified'}
-          title="Unified diff (u)"
+          data-tip="Unified diff (u)"
           aria-label="Unified diff"
           onClick={() => onSetViewMode('unified')}
         >
@@ -125,7 +125,7 @@ export function PaneBar({
           type="button"
           className="pane-icon"
           aria-pressed={viewMode === 'split'}
-          title="Split diff (u)"
+          data-tip="Split diff (u)"
           aria-label="Split diff"
           onClick={() => onSetViewMode('split')}
         >
@@ -136,7 +136,7 @@ export function PaneBar({
         type="button"
         className="pane-icon"
         aria-pressed={allCollapsed}
-        title={`${allCollapsed ? 'Expand' : 'Collapse'} all files`}
+        data-tip={`${allCollapsed ? 'Expand' : 'Collapse'} all files`}
         aria-label={`${allCollapsed ? 'Expand' : 'Collapse'} all files`}
         onClick={onToggleCollapseAll}
       >

--- a/src/ui/components/ReadingPane.tsx
+++ b/src/ui/components/ReadingPane.tsx
@@ -163,11 +163,12 @@ function FileHeader({
   return (
     // biome-ignore lint/a11y/noStaticElementInteractions: folding is also the chevron button inside
     // biome-ignore lint/a11y/useKeyWithClickEvents: folding is also the chevron button inside
-    <div className="file-header" onClick={onToggle} title="click to collapse/expand">
+    <div className="file-header" onClick={onToggle}>
       <button
         type="button"
         className={`file-chevron chevron${collapsed ? ' chevron-shut' : ''}`}
         aria-expanded={!collapsed}
+        data-tip={`${collapsed ? 'Expand' : 'Collapse'} this file`}
         aria-label={`${collapsed ? 'Expand' : 'Collapse'} ${file.path}`}
       >
         <Icon name="chev" />
@@ -194,7 +195,7 @@ function FileHeader({
       <button
         type="button"
         className="ghb file-copy"
-        title={copied ? 'Copied' : 'Copy path'}
+        data-tip={copied ? 'Copied' : 'Copy path'}
         aria-label="Copy path"
         onClick={(e) => {
           stop(e)

--- a/src/ui/components/ReviewDone.tsx
+++ b/src/ui/components/ReviewDone.tsx
@@ -126,7 +126,7 @@ export function ReviewDone({
             <button
               type="button"
               className="done-close"
-              title="Dismiss"
+              data-tip="Dismiss"
               aria-label="Dismiss"
               onClick={onDismiss}
             >

--- a/src/ui/components/ReviewLanded.tsx
+++ b/src/ui/components/ReviewLanded.tsx
@@ -81,7 +81,7 @@ export function ReviewLanded({
         <button
           type="button"
           className="done-close"
-          title="Keep them"
+          data-tip="Keep them"
           aria-label="Keep the previous review's threads"
           onClick={onDismiss}
         >

--- a/src/ui/components/ThreadRail.test.tsx
+++ b/src/ui/components/ThreadRail.test.tsx
@@ -188,7 +188,7 @@ describe('ThreadRail', () => {
     const { unmount } = render(
       <ThreadRail items={threadItems([thread({ id: 'a' })])} onResolve={vi.fn()} />,
     )
-    expect(screen.getByLabelText('Resolve thread').getAttribute('title')).toBe(
+    expect(screen.getByLabelText('Resolve thread').getAttribute('data-tip')).toBe(
       'Resolve — moves to Settled',
     )
     unmount()
@@ -199,7 +199,7 @@ describe('ThreadRail', () => {
       />,
     )
     fireEvent.click(screen.getByText(/Settled/))
-    expect(screen.getByLabelText('Reopen thread').getAttribute('title')).toBe(
+    expect(screen.getByLabelText('Reopen thread').getAttribute('data-tip')).toBe(
       'Reopen — moves back to its turn',
     )
   })

--- a/src/ui/components/ThreadRail.tsx
+++ b/src/ui/components/ThreadRail.tsx
@@ -41,7 +41,7 @@ function Row({
         type="button"
         className="crow-mark"
         aria-pressed={resolved}
-        title={resolved ? 'Reopen — moves back to its turn' : 'Resolve — moves to Settled'}
+        data-tip={resolved ? 'Reopen — moves back to its turn' : 'Resolve — moves to Settled'}
         aria-label={resolved ? 'Reopen thread' : 'Resolve thread'}
         disabled={!toggle}
         onClick={() => toggle && void toggle(item.thread.id)}
@@ -68,7 +68,7 @@ function Row({
         <button
           type="button"
           className="row-act row-act-danger crow-del"
-          title="Delete thread"
+          data-tip="Delete thread"
           aria-label="Delete thread"
           onClick={() => void onDelete(item.thread.id)}
         >
@@ -203,7 +203,7 @@ export function ThreadRail({
                 <button
                   type="button"
                   className={`row-act sec-act${batch.danger ? ' row-act-danger' : ''}`}
-                  title={batch.label}
+                  data-tip={batch.label}
                   aria-label={batch.label}
                   onClick={batch.run}
                 >

--- a/src/ui/components/Threads.test.tsx
+++ b/src/ui/components/Threads.test.tsx
@@ -282,7 +282,7 @@ describe('ThreadCard', () => {
 
     // And the same when it is the chevron doing the folding, not the resolved state.
     fireEvent.click(screen.getByTitle('expand this resolved thread'))
-    fireEvent.click(screen.getByTitle('collapse this thread'))
+    fireEvent.click(screen.getByLabelText('collapse this thread'))
     expect(document.querySelector('.thread-head')!.textContent).toContain('Reopen')
   })
 

--- a/src/ui/components/Threads.tsx
+++ b/src/ui/components/Threads.tsx
@@ -316,7 +316,7 @@ export function ThreadCard({
       type="button"
       className="btn btn-ghost btn-icon btn-sm btn-ghost-danger"
       aria-label="delete this thread"
-      title="delete this thread"
+      data-tip="delete this thread"
       onClick={() => void actions.remove!(thread.id)}
     >
       <Icon name="trash" size="sm" />
@@ -369,7 +369,7 @@ export function ThreadCard({
           type="button"
           className={`thread-shut chevron${shut ? ' chevron-shut' : ''}`}
           aria-expanded={!shut}
-          title={shut ? 'expand this thread' : 'collapse this thread'}
+          data-tip={shut ? 'expand this thread' : 'collapse this thread'}
           aria-label={shut ? 'expand this thread' : 'collapse this thread'}
           onClick={() => setShut(!shut)}
         >

--- a/src/ui/components/Tooltip.tsx
+++ b/src/ui/components/Tooltip.tsx
@@ -1,0 +1,120 @@
+import { useEffect, useRef } from 'react'
+
+/** First hover waits; after that, moving between controls feels like one toolbar. */
+const SHOW_DELAY = 400
+const WARM_GAP = 300
+
+/**
+ * One floating label for every `data-tip` element — icon-only buttons mostly.
+ * The native `title` tooltip is too slow and too quiet to read as "this app has
+ * tooltips", so controls that are nothing but an icon carry `data-tip` instead
+ * and this layer draws it: instantly warm, styled, and live — the label re-reads
+ * itself when the attribute changes, so "Copy" can become "Copied" mid-hover.
+ *
+ * Screen readers are already served by each control's aria-label; the layer is
+ * aria-hidden so nothing is announced twice.
+ */
+export function TooltipLayer() {
+  const el = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    const tip = el.current
+    if (!tip) return
+    /** The control being pointed at — armed (delay running) or already shown. */
+    let current: HTMLElement | null = null
+    let shown = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    let hiddenAt = -Infinity
+    let watcher: MutationObserver | null = null
+
+    const place = () => {
+      if (!current) return
+      const text = current.getAttribute('data-tip')
+      if (!text) {
+        hide()
+        return
+      }
+      tip.textContent = text
+      const r = current.getBoundingClientRect()
+      const w = tip.offsetWidth
+      const h = tip.offsetHeight
+      const x = Math.max(8, Math.min(r.left + r.width / 2 - w / 2, window.innerWidth - w - 8))
+      const above = r.top - h - 7
+      const y = above < 8 ? r.bottom + 7 : above
+      tip.style.left = `${Math.round(x)}px`
+      tip.style.top = `${Math.round(y)}px`
+    }
+
+    const show = () => {
+      if (!current) return
+      shown = true
+      watcher?.disconnect()
+      watcher = new MutationObserver(place)
+      watcher.observe(current, { attributes: true, attributeFilter: ['data-tip'] })
+      place()
+      if (shown) tip.classList.add('tip-on')
+    }
+
+    const hide = () => {
+      if (timer !== undefined) clearTimeout(timer)
+      timer = undefined
+      watcher?.disconnect()
+      watcher = null
+      if (shown) hiddenAt = performance.now()
+      shown = false
+      current = null
+      tip.classList.remove('tip-on')
+    }
+
+    const arm = (next: HTMLElement, instant: boolean) => {
+      if (next === current) return
+      const warm = shown || performance.now() - hiddenAt < WARM_GAP
+      hide()
+      current = next
+      if (instant || warm) show()
+      else timer = setTimeout(show, SHOW_DELAY)
+    }
+
+    const onOver = (e: Event) => {
+      const next = (e.target as Element).closest?.('[data-tip]')
+      if (next instanceof HTMLElement) arm(next, false)
+      else hide()
+    }
+    const onFocusIn = (e: Event) => {
+      const next = (e.target as Element).closest?.('[data-tip]')
+      if (next instanceof HTMLElement && next.matches(':focus-visible')) arm(next, true)
+      else hide()
+    }
+    // A click can re-anchor or unmount the control (delete, collapse); re-check
+    // once React has re-rendered. Attribute swaps are the watcher's job.
+    const onClick = () => {
+      requestAnimationFrame(() => {
+        if (current && !current.isConnected) hide()
+        else place()
+      })
+    }
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') hide()
+    }
+
+    document.addEventListener('pointerover', onOver, true)
+    document.addEventListener('focusin', onFocusIn, true)
+    document.addEventListener('focusout', hide, true)
+    document.addEventListener('click', onClick, true)
+    document.addEventListener('scroll', hide, true)
+    document.addEventListener('keydown', onKey, true)
+    window.addEventListener('resize', hide)
+    return () => {
+      hide()
+      document.removeEventListener('pointerover', onOver, true)
+      document.removeEventListener('focusin', onFocusIn, true)
+      document.removeEventListener('focusout', hide, true)
+      document.removeEventListener('click', onClick, true)
+      document.removeEventListener('scroll', hide, true)
+      document.removeEventListener('keydown', onKey, true)
+      window.removeEventListener('resize', hide)
+    }
+  }, [])
+
+  return <div ref={el} className="tip" aria-hidden="true" />
+}

--- a/src/ui/main.tsx
+++ b/src/ui/main.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './App.js'
+import { TooltipLayer } from './components/Tooltip.js'
 import { applyTheme, loadTheme } from './theme.js'
 import './styles.css'
 
@@ -11,5 +12,6 @@ applyTheme(loadTheme())
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />
+    <TooltipLayer />
   </StrictMode>,
 )

--- a/src/ui/styles.css
+++ b/src/ui/styles.css
@@ -5678,6 +5678,32 @@ i.q-now {
   animation: pop 0.28s var(--ease-out);
 }
 
+/* ---------- tooltip: the one floating label every data-tip control shares ---------- */
+
+.tip {
+  position: fixed;
+  z-index: 60; /* above modals (40) — icon buttons live inside them too */
+  max-width: 300px;
+  padding: 4px 9px;
+  border-radius: var(--r-sm);
+  background: var(--ink);
+  color: var(--paper);
+  font-family: var(--sans);
+  font-size: var(--t-11);
+  font-weight: 500;
+  line-height: 1.45;
+  letter-spacing: 0.01em;
+  overflow-wrap: break-word;
+  box-shadow: var(--lift);
+  pointer-events: none;
+  opacity: 0;
+  transition: opacity var(--dur) var(--ease-out);
+}
+
+.tip-on {
+  opacity: 1;
+}
+
 /* Motion is a preference. One move kills every transition and one-shot
  * animation; the iteration cap catches the looping indicators too. */
 @media (prefers-reduced-motion: reduce) {


### PR DESCRIPTION
User feedback said the app has no tooltips — it did, but they were native `title` tooltips: a second of hover delay, tiny, easy to write off as absent. This replaces them on every icon-only control with a styled tooltip layer.

## How

- New `TooltipLayer` (mounted once in `main.tsx`) draws one floating chip for any element carrying `data-tip`: 400ms on first hover, instant while moving between controls, shown on keyboard focus, flipped/clamped at viewport edges, hidden on Escape/scroll/blur/unmount.
- A MutationObserver re-reads the attribute while visible, so labels like “Copy path” flip to “Copied” mid-hover.
- Icon-only buttons swap `title=` for `data-tip=` (~30 across 14 files). Six controls that had no tooltip at all get one: the three `Menu` triggers (hidden while the menu is open), agent-banner dismiss, scope-chip ×, and the file-header chevron (which inherits the header’s old native title, dropped to avoid doubles).
- Text buttons keep their native `title`. aria-labels untouched; the layer is aria-hidden so nothing announces twice.

Verified in the browser in both themes: placement, warm-move, menu-open suppression, live label swap. 488 tests, tsc and biome clean.