### PR TITLE
feat: keep a dev open on the current source

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,16 +1,17 @@
 #!/usr/bin/env node
-import { spawn } from 'node:child_process'
-import { existsSync } from 'node:fs'
+import { spawn, spawnSync } from 'node:child_process'
+import { existsSync, readFileSync, writeFileSync } from 'node:fs'
 import { createServer } from 'node:net'
 import { homedir } from 'node:os'
-import { dirname, resolve } from 'node:path'
+import { dirname, join, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { detectSessionPid } from './agentSession.js'
 import { helpFor, parseCliArgs } from './cliArgs.js'
+import { SRC_STAMP } from './devStamp.js'
 import { DiffoDb } from './server/db.js'
 import { findRepoRoot, MissingBaseError, suggestedBase } from './server/git.js'
 import { RepoAlreadyServedError, startServer } from './server/index.js'
-import { ACK_NEXT_STEP, guideInherit, guideNudge } from './server/prompt.js'
+import { ACK_NEXT_STEP, CHECKOUT_ROOT, guideInherit, guideNudge } from './server/prompt.js'
 import {
   assessRunningServer,
   defaultLogPath,
@@ -124,11 +125,20 @@ const root = findRepoRoot(process.cwd())
 if (!root) fail('not inside a git repository')
 const repoPath = resolve(root)
 
+/**
+ * Only the open path settles with the source stamp: opening a review is the
+ * moment "run the current source" is the promise, while poll/reply/comment must
+ * never restart the server under a review in progress.
+ */
 async function discoverServer(): Promise<{ port: number; pid: number | null } | null> {
   const db = new DiffoDb()
   try {
-    return await settleExistingServer(db, repoPath, VERSION, (line) =>
-      process.stderr.write(`diffo: ${line}\n`),
+    return await settleExistingServer(
+      db,
+      repoPath,
+      VERSION,
+      (line) => process.stderr.write(`diffo: ${line}\n`),
+      SRC_STAMP,
     )
   } catch (err) {
     fail((err as Error).message)
@@ -148,7 +158,11 @@ function sessionHeaders(): Record<string, string> {
   }
 }
 
-async function requireServer(port?: number, base?: string): Promise<number> {
+async function requireServer(
+  port?: number,
+  base?: string,
+  srcStamp: string | null = null,
+): Promise<number> {
   try {
     return await ensureServer({
       repoPath,
@@ -158,6 +172,7 @@ async function requireServer(port?: number, base?: string): Promise<number> {
       execArgv: process.execArgv,
       port,
       base,
+      srcStamp,
       logPath: process.env.DIFFO_SERVER_LOG || defaultLogPath(repoPath),
       onStatus: (line) => process.stderr.write(`diffo: ${line}\n`),
     })
@@ -303,7 +318,7 @@ if (command.kind === 'status') {
     db.close()
   }
   const health = record ? await fetchHealth(record.port) : null
-  const verdict = record ? assessRunningServer(health, repoPath, VERSION) : 'foreign'
+  const verdict = record ? assessRunningServer(health, repoPath, VERSION, SRC_STAMP) : 'foreign'
   if (!record || verdict === 'foreign') {
     if (command.json) {
       console.log(JSON.stringify({ running: false }))
@@ -333,7 +348,11 @@ if (command.kind === 'status') {
   await printChangesetSummary(record.port)
   console.log(
     `server: port ${record.port}${pid ? ` · pid ${pid}` : ''} · v${health?.version ?? 'pre-handshake'}` +
-      (verdict === 'replace' ? ` (this CLI is v${VERSION} — the next \`diffo\` replaces it)` : ''),
+      (verdict === 'replace'
+        ? health?.version === VERSION
+          ? ` (the checkout's source changed — the next \`diffo\` replaces it)`
+          : ` (this CLI is v${VERSION} — the next \`diffo\` replaces it)`
+        : ''),
   )
   console.log(`→ ${url}`)
   process.exit(0)
@@ -492,6 +511,41 @@ async function printAgentNextStep(port: number): Promise<void> {
   )
 }
 
+/**
+ * Dev builds serve the client from the checkout's `dist/client`, which nothing
+ * rebuilds on its own — so opening a review after a source edit showed last
+ * build's UI over this build's server. Rebuild it here, before the server is
+ * settled: the server reads client files from disk per request, so even a
+ * reused server serves the fresh bundle. `.dev-stamp` (written after a
+ * successful build, into a directory vite has just emptied) makes the no-change
+ * open free. The foreground path is exempt — that is `pnpm dev:server`'s tsx
+ * watch loop, where the client is vite's dev server, not this bundle.
+ */
+function rebuildDevClient(foreground: boolean): void {
+  if (SRC_STAMP === null || foreground) return
+  const stampFile = join(CHECKOUT_ROOT, 'dist', 'client', '.dev-stamp')
+  try {
+    if (readFileSync(stampFile, 'utf-8').trim() === SRC_STAMP) return
+  } catch {
+    // no stamp yet — build below
+  }
+  process.stderr.write(`diffo: dev checkout changed — rebuilding the client bundle\n`)
+  const vite = join(
+    CHECKOUT_ROOT,
+    'node_modules',
+    '.bin',
+    process.platform === 'win32' ? 'vite.cmd' : 'vite',
+  )
+  const built = spawnSync(vite, ['build'], { cwd: CHECKOUT_ROOT, encoding: 'utf-8' })
+  if (built.status !== 0) {
+    const said = (built.stderr || built.stdout || String(built.error ?? '')).trim()
+    fail(`the client rebuild failed — fix the build, then re-run\n${said.slice(-2000)}`)
+  }
+  writeFileSync(stampFile, `${SRC_STAMP}\n`)
+}
+
+rebuildDevClient(command.foreground)
+
 const existing = await discoverServer()
 
 const takeOverPort =
@@ -538,6 +592,7 @@ if (!command.foreground) {
   const daemonPort = await requireServer(
     command.port,
     command.spec.kind === 'branch' ? command.spec.base : undefined,
+    SRC_STAMP,
   )
   const url = reviewUrl(daemonPort)
   await printChangesetSummary(daemonPort)

--- a/src/devStamp.test.ts
+++ b/src/devStamp.test.ts
@@ -1,0 +1,62 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { computeSrcStamp } from './devStamp.js'
+
+const cleanups: (() => void)[] = []
+afterEach(() => {
+  for (const fn of cleanups.splice(0)) fn()
+})
+
+function checkout(): string {
+  const root = mkdtempSync(join(tmpdir(), 'diffo-stamp-'))
+  cleanups.push(() => rmSync(root, { recursive: true, force: true }))
+  mkdirSync(join(root, 'src', 'server'), { recursive: true })
+  writeFileSync(join(root, 'src', 'cli.ts'), 'export const a = 1\n')
+  writeFileSync(join(root, 'src', 'server', 'index.ts'), 'export const b = 2\n')
+  writeFileSync(join(root, 'index.html'), '<html></html>\n')
+  return root
+}
+
+describe('computeSrcStamp', () => {
+  it('is deterministic for the same tree', () => {
+    const root = checkout()
+    expect(computeSrcStamp(root)).toBe(computeSrcStamp(root))
+  })
+
+  it('changes when a source file changes', () => {
+    const root = checkout()
+    const before = computeSrcStamp(root)
+    writeFileSync(join(root, 'src', 'server', 'index.ts'), 'export const b = 3\n')
+    expect(computeSrcStamp(root)).not.toBe(before)
+  })
+
+  it('changes when a source file is added', () => {
+    const root = checkout()
+    const before = computeSrcStamp(root)
+    writeFileSync(join(root, 'src', 'new.ts'), 'export const c = 1\n')
+    expect(computeSrcStamp(root)).not.toBe(before)
+  })
+
+  it('changes when index.html changes — the client bundle is built from it', () => {
+    const root = checkout()
+    const before = computeSrcStamp(root)
+    writeFileSync(join(root, 'index.html'), '<html><body/></html>\n')
+    expect(computeSrcStamp(root)).not.toBe(before)
+  })
+
+  it('ignores test files — they never run inside the server', () => {
+    const root = checkout()
+    const before = computeSrcStamp(root)
+    writeFileSync(join(root, 'src', 'cli.test.ts'), 'it.todo("x")\n')
+    writeFileSync(join(root, 'src', 'ui.test.tsx'), 'it.todo("y")\n')
+    expect(computeSrcStamp(root)).toBe(before)
+  })
+
+  it('survives a checkout with no index.html', () => {
+    const root = checkout()
+    rmSync(join(root, 'index.html'))
+    expect(computeSrcStamp(root)).toMatch(/^[0-9a-f]{16}$/)
+  })
+})

--- a/src/devStamp.ts
+++ b/src/devStamp.ts
@@ -1,0 +1,59 @@
+import { createHash } from 'node:crypto'
+import { readdirSync, readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { CHECKOUT_ROOT, IS_DEV } from './server/prompt.js'
+
+/**
+ * A fingerprint of the dev checkout's source. The dev CLI runs `src/` straight
+ * through tsx, so "which build is this?" isn't answered by the package version —
+ * every edit is a new build with the same version string. The stamp is what
+ * changes instead: the server reports the stamp of the source it loaded, the
+ * next `diffo` open compares it to the source on disk, and a mismatch retires
+ * the server exactly like a version bump would.
+ *
+ * Tests are skipped — they never run inside the server — and `index.html` is
+ * included because the client bundle is built from it.
+ */
+export function computeSrcStamp(checkoutRoot: string): string {
+  const hash = createHash('sha256')
+  const file = (path: string, name: string) => {
+    hash.update(name)
+    hash.update('\0')
+    hash.update(readFileSync(path))
+    hash.update('\0')
+  }
+  const walk = (dir: string, prefix: string) => {
+    const entries = readdirSync(dir, { withFileTypes: true }).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )
+    for (const entry of entries) {
+      if (entry.name.endsWith('.test.ts') || entry.name.endsWith('.test.tsx')) continue
+      const path = join(dir, entry.name)
+      const name = `${prefix}${entry.name}`
+      if (entry.isDirectory()) walk(path, `${name}/`)
+      else if (entry.isFile()) file(path, name)
+    }
+  }
+  walk(join(checkoutRoot, 'src'), 'src/')
+  try {
+    file(join(checkoutRoot, 'index.html'), 'index.html')
+  } catch {
+    // no client entry in this checkout — the src tree alone is the stamp
+  }
+  return hash.digest('hex').slice(0, 16)
+}
+
+/**
+ * This process's stamp, captured at import — for the server that means the
+ * source it actually loaded, not whatever is on disk by the time someone asks.
+ * Null outside dev (a published build has no `src/` to stamp, and its version
+ * string already does this job).
+ */
+export const SRC_STAMP: string | null = (() => {
+  if (!IS_DEV) return null
+  try {
+    return computeSrcStamp(CHECKOUT_ROOT)
+  } catch {
+    return null
+  }
+})()

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ import { extname, resolve, sep } from 'node:path'
 import { serve } from '@hono/node-server'
 import { type Context, Hono } from 'hono'
 import { stream, streamSSE } from 'hono/streaming'
+import { SRC_STAMP } from '../devStamp.js'
 import {
   type Anchor,
   type Coverage,
@@ -160,6 +161,9 @@ export function createApp(
       app: 'diffo',
       version: VERSION,
       pid: process.pid,
+      // Captured at startup, so it names the source this server LOADED — the
+      // CLI compares it to the checkout on disk and retires a stale dev server.
+      ...(SRC_STAMP === null ? {} : { srcStamp: SRC_STAMP }),
     }),
   )
 

--- a/src/serverLifecycle.test.ts
+++ b/src/serverLifecycle.test.ts
@@ -64,6 +64,23 @@ describe('assessRunningServer', () => {
   it('treats a non-diffo squatter as foreign even when it echoes ok', () => {
     expect(assessRunningServer({ ok: true }, REPO, V)).toBe('foreign')
   })
+
+  it('reuses a same-build server whose source stamp matches', () => {
+    expect(assessRunningServer(ours({ srcStamp: 'aaa' }), REPO, V, 'aaa')).toBe('reuse')
+  })
+
+  it('replaces a same-build server started from other source', () => {
+    expect(assessRunningServer(ours({ srcStamp: 'aaa' }), REPO, V, 'bbb')).toBe('replace')
+  })
+
+  it('replaces a same-build server that reports no stamp when one is expected', () => {
+    expect(assessRunningServer(ours(), REPO, V, 'aaa')).toBe('replace')
+  })
+
+  it('ignores the stamp entirely when none is expected — polls must not churn', () => {
+    expect(assessRunningServer(ours({ srcStamp: 'aaa' }), REPO, V)).toBe('reuse')
+    expect(assessRunningServer(ours({ srcStamp: 'aaa' }), REPO, V, null)).toBe('reuse')
+  })
 })
 
 describe('serverSpawnArgs', () => {

--- a/src/serverLifecycle.ts
+++ b/src/serverLifecycle.ts
@@ -14,17 +14,28 @@ export interface ServerHealth {
   app?: string
   version?: string
   pid?: number
+  /** Dev builds only: the source fingerprint the server was started from. */
+  srcStamp?: string
 }
 
 export type ServerAssessment = 'reuse' | 'replace' | 'foreign'
 
+/**
+ * `srcStamp` is the dev-build refinement of the version check: a dev server's
+ * version never changes across source edits, so an expected stamp (non-null)
+ * makes a server started from other source a 'replace' too. Callers that must
+ * not churn a running review (poll, reply) simply pass none.
+ */
 export function assessRunningServer(
   health: ServerHealth | null,
   repoPath: string,
   version: string,
+  srcStamp: string | null = null,
 ): ServerAssessment {
   if (health?.ok !== true || health.repo !== repoPath) return 'foreign'
-  return health.app === 'diffo' && health.version === version ? 'reuse' : 'replace'
+  if (health.app !== 'diffo' || health.version !== version) return 'replace'
+  if (srcStamp !== null && health.srcStamp !== srcStamp) return 'replace'
+  return 'reuse'
 }
 
 /**
@@ -132,15 +143,18 @@ export async function settleExistingServer(
   repoPath: string,
   version: string,
   onStatus: (line: string) => void = () => {},
+  srcStamp: string | null = null,
 ): Promise<DiscoveredServer | null> {
   const record = db.getServer(repoPath)
   if (!record) return null
   const health = await fetchHealth(record.port)
-  const verdict = assessRunningServer(health, repoPath, version)
+  const verdict = assessRunningServer(health, repoPath, version, srcStamp)
   if (verdict === 'reuse') return { port: record.port, pid: health?.pid ?? record.pid ?? null }
   if (verdict === 'replace') {
     onStatus(
-      `replacing the diffo server from another build (${health?.version ?? 'pre-handshake'} → ${version})`,
+      health?.version === version
+        ? `replacing the dev server — the checkout's source changed since it started`
+        : `replacing the diffo server from another build (${health?.version ?? 'pre-handshake'} → ${version})`,
     )
     if (!(await retireServer(record.port, record.pid ?? null, health?.pid ?? null))) {
       throw new Error(
@@ -167,6 +181,8 @@ export interface EnsureServerOptions {
   dbPath?: string
   spawnTimeoutMs?: number
   onStatus?: (line: string) => void
+  /** Dev builds: replace a running server started from other source. */
+  srcStamp?: string | null
 }
 
 export interface EnsureServerDeps {
@@ -240,7 +256,13 @@ export async function ensureServer(
   const status = opts.onStatus ?? (() => {})
   const db = new DiffoDb(opts.dbPath)
   try {
-    const existing = await settleExistingServer(db, opts.repoPath, opts.version, status)
+    const existing = await settleExistingServer(
+      db,
+      opts.repoPath,
+      opts.version,
+      status,
+      opts.srcStamp ?? null,
+    )
     if (existing) return existing.port
 
     status('no diffo server for this repo — starting one')
@@ -258,7 +280,10 @@ export async function ensureServer(
       const row = db.getServer(opts.repoPath)
       if (!row) return false
       const health = await fetchHealth(row.port, 500)
-      if (assessRunningServer(health, opts.repoPath, opts.version) !== 'reuse') return false
+      if (
+        assessRunningServer(health, opts.repoPath, opts.version, opts.srcStamp ?? null) !== 'reuse'
+      )
+        return false
       port = row.port
       return true
     }, opts.spawnTimeoutMs ?? 8000)

--- a/src/skill.ts
+++ b/src/skill.ts
@@ -52,7 +52,13 @@ run the released CLI instead of the checkout this skill exists to exercise.
 
 The reviewer's browser tab and header say **diffo-dev**, so a review opened
 this way is never mistaken for one opened by the shipped \`${SKILL_NAME}\`
-skill, which is installed alongside this one and unaffected by it.`
+skill, which is installed alongside this one and unaffected by it.
+
+Opening a review keeps itself current on its own: if the checkout's source
+changed since the last open, the CLI rebuilds the client bundle and replaces a
+running stale server before answering — expect a few extra seconds and a
+"rebuilding the client bundle" / "replacing the dev server" line then, and
+never rebuild or restart anything yourself.`
   return `---
 name: ${name}
 description: ${isDev ? DEV_SKILL_DESCRIPTION : SKILL_DESCRIPTION}


### PR DESCRIPTION
Opening a review with the dev CLI could serve last build's client (a stale `dist/client`) over last session's server (a reused daemon — reuse only compared the package version, which source edits never change).

Dev builds now stamp the checkout's source (content hash of `src/` + `index.html`, tests excluded). On open, a stamp mismatch rebuilds the client bundle and retires the stale daemon through the existing replace machinery; `poll`/`reply`/`comment` pass no stamp, so a mid-review edit never restarts the server under the reviewer. Released builds carry a null stamp and behave exactly as before (verified against the built `dist/cli.mjs`: identical health payload, no rebuild, no replace).
