### PR TITLE
fix(ui): render the reading pane in the rail's tree order

### DIFF
--- a/src/ui/App.tsx
+++ b/src/ui/App.tsx
@@ -21,7 +21,7 @@ import { Icon, IconSprite } from './components/Icon.js'
 import { InviteAgent } from './components/InviteAgent.js'
 import { LeftPanel } from './components/LeftPanel.js'
 import { Monitor } from './components/Monitor.js'
-import { Nav } from './components/Nav.js'
+import { Nav, treeOrder } from './components/Nav.js'
 import { ReadingPane, type ReviewComments, type ViewMode } from './components/ReadingPane.js'
 import { Shortcuts } from './components/Shortcuts.js'
 import { ThreadRail } from './components/ThreadRail.js'
@@ -278,7 +278,10 @@ function Review() {
     [data, review, viewed],
   )
 
-  const allFiles = useMemo(() => data?.files ?? [], [data])
+  // One canonical order for the whole review: the rail's tree, flattened. The
+  // pane, J/K, and "next unreviewed" all walk it, so the rail always mirrors
+  // the pane instead of the raw git order.
+  const allFiles = useMemo(() => treeOrder(data?.files ?? []), [data])
   const isFileDone = useCallback((file: FileChange) => isFileViewed(file, viewed), [viewed])
   const filter = useReviewFilter(allFiles, isFileDone, {
     on: onlyChanged,
@@ -407,7 +410,7 @@ function Review() {
   }, [activeThreads])
 
   const coverage: Coverage = useMemo(() => {
-    const unread = (data?.files ?? []).filter((f) => !isFileViewed(f, viewed))
+    const unread = allFiles.filter((f) => !isFileViewed(f, viewed))
     const changedFiles = unread.filter((f) => movedPaths.has(f.path)).map((f) => f.path)
     const changedSet = new Set(changedFiles)
     const excluded = new Set(filter.scope.excludedPaths)
@@ -426,7 +429,15 @@ function Review() {
         .filter((f) => !commentedPaths.has(f.path) && !excluded.has(f.path))
         .map((f) => f.path),
     }
-  }, [data, progress, fileProgress, viewed, movedPaths, commentedPaths, filter.scope.excludedPaths])
+  }, [
+    allFiles,
+    progress,
+    fileProgress,
+    viewed,
+    movedPaths,
+    commentedPaths,
+    filter.scope.excludedPaths,
+  ])
 
   const clearThreads = useCallback(async () => {
     await reviewApi.clear()
@@ -661,7 +672,7 @@ function Review() {
   )
 
   const nextUnreviewed = useCallback(() => {
-    const file = (data?.files ?? []).find((f) => !isFileViewed(f, viewed))
+    const file = allFiles.find((f) => !isFileViewed(f, viewed))
     if (!file) return
     revealFile(file.path)
     setCollapsed((prev) => {
@@ -676,7 +687,7 @@ function Review() {
       const node = document.getElementById(fileAnchor(file.path))
       if (node) glideTo(node, flashLanding)
     })
-  }, [data, viewed, revealFile])
+  }, [allFiles, viewed, revealFile])
 
   const openThread = useCallback(
     (item: { threadId: string; path: string | null; gone?: boolean }) => {
@@ -927,7 +938,7 @@ function Review() {
           settledCount={settledThreads}
           files={
             <Nav
-              files={data.files}
+              files={allFiles}
               viewed={viewed}
               selectedPath={selectedPath}
               onPickFile={pickFile}

--- a/src/ui/components/Nav.test.tsx
+++ b/src/ui/components/Nav.test.tsx
@@ -4,7 +4,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ReviewThread } from '../../shared/review.js'
 import type { DiffLine, FileChange, Hunk, LineKind } from '../../shared/types.js'
 import { fileMark } from '../fileMarks.js'
-import { buildTree, Nav, type TreeDir, type TreeNode } from './Nav.js'
+import { buildTree, Nav, type TreeDir, type TreeNode, treeOrder } from './Nav.js'
 
 afterEach(cleanup)
 
@@ -59,6 +59,24 @@ describe('buildTree', () => {
   it('sorts folders before files, each alphabetically', () => {
     const tree = buildTree([file('z.md'), file('a/x.ts'), file('b.md'), file('c/y.ts')])
     expect(shape(tree)).toEqual([{ a: ['a/x.ts'] }, { c: ['c/y.ts'] }, 'b.md', 'z.md'])
+  })
+})
+
+describe('treeOrder', () => {
+  it('flattens files in the exact order the rail renders them', () => {
+    // Git order would put src/c.ts before src/server/a.ts; the rail does not.
+    const ordered = treeOrder([
+      file('src/c.ts'),
+      file('src/server/a.ts'),
+      file('z.md'),
+      file('docs/index.md'),
+    ])
+    expect(ordered.map((f) => f.path)).toEqual([
+      'docs/index.md',
+      'src/server/a.ts',
+      'src/c.ts',
+      'z.md',
+    ])
   })
 })
 

--- a/src/ui/components/Nav.tsx
+++ b/src/ui/components/Nav.tsx
@@ -73,6 +73,13 @@ function filesUnder(node: TreeNode): FileChange[] {
   return node.children.flatMap(filesUnder)
 }
 
+/** The rail's tree, flattened — the one file order the whole review reads in.
+ * The reading pane, J/K, and "next unreviewed" all follow it, so the rail is
+ * always a map of the pane. */
+export function treeOrder(files: FileChange[]): FileChange[] {
+  return buildTree(files).flatMap(filesUnder)
+}
+
 function FileRow({
   file,
   depth,


### PR DESCRIPTION
The rail sorts files as a tree — folders first, then files, each alphabetical by basename — while the reading pane rendered the raw git order, so the two disagreed whenever a directory held both subdirectories and files (src/c.ts before src/server/a.ts in the pane, after it in the rail).

Flatten the rail's tree into one canonical order (treeOrder) and route allFiles through it, so the pane, J/K navigation, "next unreviewed", and the finish-review coverage lists all read in the order the rail shows.
