### PR TITLE
feat: Mark an agent reply as interim with `diffo reply --more`

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -431,7 +431,7 @@ if (command.kind === 'reply') {
   const { status, body } = await postJson(
     port,
     `/api/review/threads/${encodeURIComponent(command.threadId)}/messages`,
-    { author: 'agent', text: message },
+    { author: 'agent', text: message, ...(command.more ? { more: true } : {}) },
   )
   if (status === 404) fail(`no thread with id '${command.threadId}'`)
   if (status !== 200) fail(`reply failed (${status})`)
@@ -441,7 +441,7 @@ if (command.kind === 'reply') {
       ok: true,
       threadId: thread.id,
       state: thread.state,
-      next_step: ACK_NEXT_STEP.reply,
+      next_step: command.more ? ACK_NEXT_STEP.replyMore : ACK_NEXT_STEP.reply,
     }),
   )
   process.exit(0)

--- a/src/cliArgs.test.ts
+++ b/src/cliArgs.test.ts
@@ -89,15 +89,26 @@ describe('parseCliArgs — agent verbs', () => {
       kind: 'reply',
       threadId: 't-1',
       message: 'done',
+      more: false,
     })
     expect(parseCliArgs(['reply', 't-1', '-m', 'done'])).toMatchObject({ message: 'done' })
     expect(parseCliArgs(['reply', 't-1'])).toEqual({
       kind: 'reply',
       threadId: 't-1',
       message: null,
+      more: false,
     })
     expect(parseCliArgs(['reply'])).toMatchObject({ kind: 'error' })
     expect(parseCliArgs(['reply', 't-1', 'oops'])).toMatchObject({ kind: 'error' })
+  })
+
+  it('reply takes --more; the other verbs refuse it', () => {
+    expect(parseCliArgs(['reply', 't-1', '--more', '-m', 'digging in'])).toMatchObject({
+      kind: 'reply',
+      more: true,
+    })
+    expect(parseCliArgs(['comment', 'a.ts', '--more', '-m', 'x'])).toMatchObject({ kind: 'error' })
+    expect(parseCliArgs(['poll', '--more'])).toMatchObject({ kind: 'error' })
   })
 
   it('comment anchors to a line, a file, or (no file) the changeset', () => {

--- a/src/cliArgs.ts
+++ b/src/cliArgs.ts
@@ -79,7 +79,10 @@ The loop:
    answer in the reply and no edit. Your edits reach the reviewer live.
 5. Reply: \`diffo reply <threadId> --message "<text>"\` (pipe long replies on
    stdin) — concise, addressed to the reviewer. Markdown renders; a
-   \`\`\`mermaid fence draws a diagram.
+   \`\`\`mermaid fence draws a diagram. A reply that only promises a
+   follow-up ("I'll investigate and report back") goes out with \`--more\` —
+   the reviewer keeps seeing you at work — and the real answer follows as a
+   plain reply before the next poll.
 6. Comment (sparingly): \`diffo comment [<file>] [--line <n>] -m "<text>"\`
    starts a thread in your voice — a concern, or context that helps the read.
 7. Poll again only when the whole batch is handled — a new poll tells the
@@ -117,6 +120,10 @@ Usage: diffo reply <threadId> --message "<text>"
 
 Thread ids arrive in poll payloads. Each run posts one message, so don't
 re-run a reply that succeeded.
+--more marks the reply as interim: you are still working, and a follow-up
+reply on this thread is promised. The reviewer keeps seeing the thread as
+"with the agent" until your next plain reply; going quiet instead marks it
+unanswered.
 Messages render GitHub-flavored markdown; a \`\`\`mermaid fence renders as a
 diagram in the review.
 
@@ -205,7 +212,7 @@ export type CliCommand =
       foreground: boolean
     }
   | { kind: 'poll' }
-  | { kind: 'reply'; threadId: string; message: string | null }
+  | { kind: 'reply'; threadId: string; message: string | null; more: boolean }
   | { kind: 'comment'; file: string | null; line: number | null; message: string | null }
   | { kind: 'end' }
   | { kind: 'setup' }
@@ -353,6 +360,7 @@ function parseVerb(verb: string, rest: string[]): CliCommand {
       options: {
         message: { type: 'string', short: 'm' },
         line: { type: 'string' },
+        more: { type: 'boolean' },
         json: { type: 'boolean' },
         help: { type: 'boolean', short: 'h' },
       },
@@ -366,6 +374,10 @@ function parseVerb(verb: string, rest: string[]): CliCommand {
 
   if (values.json && verb !== 'status') {
     return { kind: 'error', message: `'${verb}' takes no --json` }
+  }
+
+  if (values.more && verb !== 'reply') {
+    return { kind: 'error', message: `'${verb}' takes no --more` }
   }
 
   if (
@@ -397,7 +409,7 @@ function parseVerb(verb: string, rest: string[]): CliCommand {
     if (values.line !== undefined) {
       return { kind: 'error', message: 'reply takes no --line' }
     }
-    return { kind: 'reply', threadId, message: values.message ?? null }
+    return { kind: 'reply', threadId, message: values.message ?? null, more: values.more === true }
   }
 
   const file = positionals[0] ?? null

--- a/src/server/delivery.test.ts
+++ b/src/server/delivery.test.ts
@@ -147,6 +147,54 @@ describe('DeliveryQueue', () => {
     expect(q.deliveredThreadIds()).toEqual([])
   })
 
+  it('an interim reply keeps the thread on the clock — still working, still delivered', () => {
+    const q = new DeliveryQueue()
+    q.enqueueThreads(['t1'])
+    q.confirm(q.take()!, ['t1'])
+    const waited = q.agentReplied('t1', true)
+    expect(typeof waited).toBe('number')
+    // The thread stays in the agent's hands: spinner stays, presence stays working.
+    expect(q.deliveredThreadIds()).toEqual(['t1'])
+    expect(q.presence()).toBe('working')
+    expect(q.presenceDetail().reason).toBe('delivered')
+    // The follow-up concludes it like any reply, timed from the original delivery.
+    expect(typeof q.agentReplied('t1')).toBe('number')
+    expect(q.deliveredThreadIds()).toEqual([])
+    expect(q.presenceDetail().reason).toBe('replied')
+  })
+
+  it('a --more after a plain reply re-arms the clock — the batch owes the follow-up again', () => {
+    const q = new DeliveryQueue()
+    q.enqueueThreads(['t1'])
+    q.confirm(q.take()!, ['t1'])
+    q.agentReplied('t1')
+    expect(q.deliveredThreadIds()).toEqual([])
+    q.agentReplied('t1', true)
+    expect(q.deliveredThreadIds()).toEqual(['t1'])
+    expect(q.presence()).toBe('working')
+    expect(q.presenceDetail().reason).toBe('delivered')
+  })
+
+  it('a --more with no live batch arms nothing — there is no clock to keep', () => {
+    const q = new DeliveryQueue()
+    expect(q.agentReplied('t1', true)).toBeNull()
+    expect(q.deliveredThreadIds()).toEqual([])
+    expect(q.presence()).toBe('waiting')
+  })
+
+  it('a batch closed after only an interim reply counts the thread unanswered', async () => {
+    const q = new DeliveryQueue(5 * 60_000, 10, {}, 0)
+    q.enqueueThreads(['t1'])
+    q.confirm(q.take()!, ['t1'])
+    q.agentReplied('t1', true)
+    let closed: { unanswered: string[] } | null = null
+    q.onBatchClosed((c) => (closed = c))
+    // The re-poll closes the batch — the promised follow-up never came.
+    void q.attach()
+    expect(closed).not.toBeNull()
+    expect(closed!.unanswered).toEqual(['t1'])
+  })
+
   it('a mid-batch reply keeps working — the agent still owes answers', () => {
     const q = new DeliveryQueue()
     q.enqueueThreads(['t1', 't2'])

--- a/src/server/delivery.ts
+++ b/src/server/delivery.ts
@@ -484,10 +484,23 @@ export class DeliveryQueue {
   }
 
   /** The agent replied on a thread. Returns how long since that thread's feedback
-   * was delivered, or null when the reply wasn't an answer to a delivery. */
-  agentReplied(threadId: string): number | null {
+   * was delivered, or null when the reply wasn't an answer to a delivery.
+   * `interim` (a `--more` reply) keeps the thread on the clock: a follow-up is
+   * still owed, so the spinner stays and a batch that closes without the
+   * follow-up counts the thread unanswered. */
+  agentReplied(threadId: string, interim = false): number | null {
     const at = this.deliveredAt.get(threadId)
-    this.deliveredAt.delete(threadId)
+    if (!interim) {
+      this.deliveredAt.delete(threadId)
+    } else if (at === undefined && this.batch) {
+      // A promise made after the thread left the clock (an earlier plain reply
+      // already concluded it) re-arms it: the live batch owes the follow-up
+      // now, and closing without it must read as unanswered.
+      this.deliveredAt.set(threadId, Date.now())
+      if (!this.batch.threadIds.includes(threadId)) this.batch.threadIds.push(threadId)
+      this.awaitingReply = true
+      this.clearGrace()
+    }
     if (this.batch) this.batch.sawReply = true
     if (this.deliveredAt.size > 0) {
       if (this.awaitingReply) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -259,9 +259,12 @@ export function createApp(
       // Refresh the OWNER's clock, never retarget it: a reply from a second session
       // must not point the liveness watch at its harness (delivery.ts `noteSession`).
       queue?.noteSession(parseSessionPid(c.req.header('x-diffo-session-pid')))
-      const waitedMs = queue?.agentReplied(id) ?? null
+      // An interim reply (`--more`): a follow-up is promised, so the thread
+      // stays on the delivery clock and keeps waiting on the agent.
+      const more = body?.more === true
+      const waitedMs = queue?.agentReplied(id, more) ?? null
       const seenThroughMs = waitedMs === null ? undefined : Date.now() - waitedMs
-      const thread = review.addMessage(id, 'agent', text, false, seenThroughMs)
+      const thread = review.addMessage(id, 'agent', text, false, seenThroughMs, more)
       if (!thread) return c.json({ error: 'no such thread' }, 404)
       if (waitedMs !== null) review.annotateAgentReplies([thread.id], waitedMs)
       return c.json({ thread, delivered: false })
@@ -830,6 +833,14 @@ export function markDevIndex(html: string, isDev: boolean): string {
 }
 
 export function rehydrateQueue(review: ReviewStore, queue: DeliveryQueue): void {
+  // A follow-up promised before the restart has no live batch left to conclude
+  // it — downgrade to unanswered so the UI stops waiting. Self-healing: the
+  // follow-up that does arrive clears the mark like any reply.
+  const promised = review
+    .get()
+    .threads.filter((t) => t.awaitingFollowUp === true)
+    .map((t) => t.id)
+  if (promised.length > 0) review.markUnanswered(promised)
   const state = review.get()
   queue.enqueueThreads(undeliveredThreadIds(state.threads))
   const finish = state.lastFinish

--- a/src/server/prompt.test.ts
+++ b/src/server/prompt.test.ts
@@ -320,6 +320,24 @@ describe('reply protocol rules', () => {
     expect(prompt).toContain('id: t-2')
   })
 
+  it('a --more reply does not count as answered — Finish still ships the thread whole', () => {
+    const promised = thread({
+      id: 't-p',
+      awaitingFollowUp: true,
+      messages: [
+        { id: 'm1', author: 'reviewer', text: 'why?', at: '' },
+        { id: 'm2', author: 'agent', text: 'digging in — back soon', at: '' },
+      ],
+    })
+    const prompt = buildFinishPrompt([promised], ctx, {
+      viewedHunks: 1,
+      totalHunks: 1,
+      skippedFiles: [],
+    })
+    expect(prompt).toContain('id: t-p')
+    expect(prompt).not.toContain('you already answered')
+  })
+
   it('a closing note the agent already replied to still leads the batch in full', () => {
     const note = thread({
       id: 't-note',

--- a/src/server/prompt.ts
+++ b/src/server/prompt.ts
@@ -122,6 +122,8 @@ export function nextStepFor(kind: 'threads' | 'finish' | 'cleared', actionable: 
 
 export const ACK_NEXT_STEP = {
   reply: `When every thread is handled, run \`${CLI_COMMANDS.poll}\` again to keep listening (${POLL_STANCE}).`,
+  replyMore:
+    'Interim reply posted — the reviewer still sees you working on this thread. Post the follow-up as a plain reply (no --more) BEFORE your next poll: re-polling closes the batch and counts the promise as never kept.',
   comment: `It's in the review as your comment, labeled as yours — the reviewer replies to take it up, or resolves it. Continue with the review threads, then run \`${CLI_COMMANDS.poll}\`.`,
   end: 'Detached. Do not reopen or re-poll this review unless the user asks — deliver anything remaining directly in the conversation.',
 } as const
@@ -186,9 +188,10 @@ const INTENT_CONTRACT: Record<ThreadIntent, string> = {
 const UNLABELED_CONTRACT =
   '- Unlabeled threads: judge from the text — a question wants an answer, not an edit.'
 
-/** The agent spoke last: the thread is answered until the reviewer says more. */
+/** The agent spoke last: the thread is answered until the reviewer says more.
+ * A reply that promised a follow-up (`--more`) is not an answer yet. */
 export function answeredByAgent(thread: ReviewThread): boolean {
-  return thread.messages.at(-1)?.author === 'agent'
+  return thread.messages.at(-1)?.author === 'agent' && thread.awaitingFollowUp !== true
 }
 
 /** The closing note is the reviewer summing up, so it earns an answer even when it
@@ -244,7 +247,7 @@ export function replyProtocol(
       : ''
   // Finish re-ships every sent thread, answered ones included; without this line
   // the agent re-answers each and the reviewer gets duplicate replies.
-  const answeredNote = threads.some((t) => t.messages.at(-1)?.author === 'agent')
+  const answeredNote = threads.some((t) => answeredByAgent(t))
     ? [
         "   - Some threads end with your own earlier reply — if nothing new was asked since, don't reply to them again.",
       ]
@@ -268,6 +271,10 @@ ${[...intentContract(threads).map((line) => `   ${line}`), ...answeredNote].join
    is fixed, verify it the cheapest honest way (run the relevant test, re-read
    the change) and mention what you checked.
    Reply as soon as a thread is handled; don't save replies for the end.
+   A reply that only promises a follow-up ("I'll investigate and report
+   back") is not an answer — post it with \`--more\` so the reviewer keeps
+   seeing you at work on that thread, then post the real answer as a plain
+   reply (no \`--more\`) before your next poll.
    Replies and comment threads render GitHub-flavored markdown, and a
    \`\`\`mermaid fence renders as a diagram — use one when a flow, sequence,
    or state picture explains the change better than prose. Keep it small

--- a/src/server/rehydrate.test.ts
+++ b/src/server/rehydrate.test.ts
@@ -130,6 +130,22 @@ describe('rehydrateQueue — feedback outlives the process that queued it', () =
     expect(snapshot).toEqual({ kind: 'threads', threadIds: [thread.id] })
   })
 
+  it('downgrades a promised follow-up to unanswered — no live batch is left to conclude it', () => {
+    const { store, restart } = makeReview()
+    const thread = store.createThread(anchor(), 'why the cast here?', null)
+    store.send(thread.id)
+    store.addMessage(thread.id, 'agent', 'digging in — back soon', false, undefined, true)
+
+    const restarted = restart()
+    const queue = new DeliveryQueue()
+    rehydrateQueue(restarted, queue)
+    const after = restarted.get().threads[0]!
+    expect(after.unanswered).toBe(true)
+    expect('awaitingFollowUp' in after).toBe(false)
+    // Owed BY the agent, not by the reviewer — never re-queued for delivery.
+    expect(queue.queuedThreadIds()).toEqual([])
+  })
+
   it('holds nothing for a review with nothing outstanding', () => {
     const { store, restart } = makeReview()
     store.createThread(anchor(), 'still drafting this', null)

--- a/src/server/review-api.test.ts
+++ b/src/server/review-api.test.ts
@@ -836,6 +836,61 @@ describe('the pull loop', () => {
     expect(String(repoll.prompt)).toMatch(/because X[\s\S]*raced follow-up/)
   })
 
+  it('a --more reply keeps the thread with the agent; the follow-up settles it', async () => {
+    const { app, review, queue } = setup()
+    const created = await post(app, '/api/review/threads', {
+      anchor: { kind: 'changeset' },
+      text: 'why?',
+    })
+    const thread = (await created.json()) as ReviewThread
+    await post(app, `/api/review/threads/${thread.id}/send`)
+    await pollResult(await app.request('/api/agent/poll', { headers: { 'x-diffo-agent': 'cli' } }))
+
+    await post(app, `/api/review/threads/${thread.id}/messages`, {
+      author: 'agent',
+      text: 'digging in — back soon',
+      more: true,
+    })
+    const interim = review.get().threads[0]!
+    expect(interim.awaitingFollowUp).toBe(true)
+    expect(interim.messages.at(-1)!.durationMs).toBeDefined()
+    // Still in the agent's hands: the spinner and presence both keep waiting.
+    expect(queue.deliveredThreadIds()).toEqual([thread.id])
+    expect(queue.presence()).toBe('working')
+    expect(queue.presenceDetail().reason).toBe('delivered')
+
+    await post(app, `/api/review/threads/${thread.id}/messages`, {
+      author: 'agent',
+      text: 'found it — fixed',
+    })
+    const settled = review.get().threads[0]!
+    expect('awaitingFollowUp' in settled).toBe(false)
+    expect(queue.deliveredThreadIds()).toEqual([])
+    expect(queue.presenceDetail().reason).toBe('replied')
+  })
+
+  it('a batch concluded on only a --more reply marks the thread unanswered', async () => {
+    const { app, review } = setup()
+    const created = await post(app, '/api/review/threads', {
+      anchor: { kind: 'changeset' },
+      text: 'why?',
+    })
+    const thread = (await created.json()) as ReviewThread
+    await post(app, `/api/review/threads/${thread.id}/send`)
+    await pollResult(await app.request('/api/agent/poll', { headers: { 'x-diffo-agent': 'cli' } }))
+    await post(app, `/api/review/threads/${thread.id}/messages`, {
+      author: 'agent',
+      text: 'digging in — back soon',
+      more: true,
+    })
+
+    // The agent detaches without the promised follow-up.
+    await post(app, '/api/agent/end', {})
+    const after = review.get().threads[0]!
+    expect(after.unanswered).toBe(true)
+    expect('awaitingFollowUp' in after).toBe(false)
+  })
+
   it('a reply with no delivery outstanding still appends at the end', async () => {
     const { app, review } = setup()
     const created = await post(app, '/api/review/threads', {

--- a/src/server/review.test.ts
+++ b/src/server/review.test.ts
@@ -358,6 +358,76 @@ describe('ReviewStore', () => {
     store.clearUnanswered([thread.id])
     expect(pings).toBe(0)
   })
+
+  it('a --more reply promises a follow-up; the next plain reply settles it', () => {
+    const root = tempRoot()
+    const store = makeStore(root)
+    const thread = store.createThread(hunkAnchor('h1'), 'why this?', null)
+    store.send(thread.id)
+
+    store.addMessage(thread.id, 'agent', 'digging in — back soon', false, undefined, true)
+    expect(store.get().threads[0]!.awaitingFollowUp).toBe(true)
+    expect(makeStore(root).get().threads[0]!.awaitingFollowUp).toBe(true)
+
+    store.addMessage(thread.id, 'agent', 'found it — fixed')
+    expect('awaitingFollowUp' in store.get().threads[0]!).toBe(false)
+  })
+
+  it('a reviewer message leaves the promise standing — the agent still owes the ending', () => {
+    const store = makeStore(tempRoot())
+    const thread = store.createThread(hunkAnchor('h1'), 'why this?', null)
+    store.send(thread.id)
+    store.addMessage(thread.id, 'agent', 'checking', false, undefined, true)
+
+    store.addMessage(thread.id, 'reviewer', 'also look at the other branch')
+    expect(store.get().threads[0]!.awaitingFollowUp).toBe(true)
+  })
+
+  it('another --more renews the promise instead of settling it', () => {
+    const store = makeStore(tempRoot())
+    const thread = store.createThread(hunkAnchor('h1'), 'why this?', null)
+    store.send(thread.id)
+    store.addMessage(thread.id, 'agent', 'checking', false, undefined, true)
+    store.addMessage(thread.id, 'agent', 'still checking', false, undefined, true)
+    expect(store.get().threads[0]!.awaitingFollowUp).toBe(true)
+  })
+
+  it('markUnanswered settles the promise — moved on and follow-up coming cannot both be true', () => {
+    const store = makeStore(tempRoot())
+    const thread = store.createThread(hunkAnchor('h1'), 'why this?', null)
+    store.send(thread.id)
+    store.addMessage(thread.id, 'agent', 'checking', false, undefined, true)
+
+    store.markUnanswered([thread.id])
+    const after = store.get().threads[0]!
+    expect(after.unanswered).toBe(true)
+    expect('awaitingFollowUp' in after).toBe(false)
+  })
+
+  it('resolving settles the promise along with the thread', () => {
+    const store = makeStore(tempRoot())
+    const thread = store.createThread(hunkAnchor('h1'), 'why this?', null)
+    store.send(thread.id)
+    store.addMessage(thread.id, 'agent', 'checking', false, undefined, true)
+
+    store.setState(thread.id, 'resolved')
+    expect('awaitingFollowUp' in store.get().threads[0]!).toBe(false)
+  })
+
+  it('the follow-up lands after the interim reply, before raced reviewer words', async () => {
+    const tick = () => new Promise((r) => setTimeout(r, 20))
+    const store = makeStore(tempRoot())
+    const thread = store.createThread(hunkAnchor('h1'), 'why this?', null)
+    store.send(thread.id)
+    const deliveredAt = Date.now()
+    store.addMessage(thread.id, 'agent', 'interim', false, deliveredAt, true)
+    await tick()
+    store.addMessage(thread.id, 'reviewer', 'raced in meanwhile')
+
+    store.addMessage(thread.id, 'agent', 'the real answer', false, deliveredAt)
+    const texts = store.get().threads[0]!.messages.map((m) => m.text)
+    expect(texts).toEqual(['why this?', 'interim', 'the real answer', 'raced in meanwhile'])
+  })
 })
 
 describe('parseReview', () => {
@@ -457,6 +527,25 @@ describe('parseReview', () => {
     )
     expect(parsed!.threads[0]!.messages[0]!.author).toBe('agent')
     expect('role' in parsed!.threads[0]!).toBe(false)
+  })
+
+  it('round-trips awaitingFollowUp; unanswered wins when a hand-edited file carries both', () => {
+    const stored = (extra: Record<string, unknown>) =>
+      JSON.stringify({
+        threads: [
+          {
+            id: 't',
+            state: 'sent',
+            anchor: { kind: 'file', path: 'a.ts' },
+            messages: [{ author: 'agent', text: 'checking' }],
+            ...extra,
+          },
+        ],
+      })
+    expect(parseReview(stored({ awaitingFollowUp: true }))!.threads[0]!.awaitingFollowUp).toBe(true)
+    const both = parseReview(stored({ awaitingFollowUp: true, unanswered: true }))!.threads[0]!
+    expect(both.unanswered).toBe(true)
+    expect('awaitingFollowUp' in both).toBe(false)
   })
 
   it('round-trips seenHead and the landed marker, and drops a sha-less marker', () => {

--- a/src/server/review.ts
+++ b/src/server/review.ts
@@ -136,15 +136,25 @@ export class ReviewStore {
     text: string,
     withheld = false,
     seenThroughMs?: number,
+    followUp = false,
   ): ReviewThread | null {
     return this.update(threadId, ({ unanswered: _answered, ...thread }) => {
       const message = { id: randomUUID(), author, text, at: new Date().toISOString() }
+      // Raced = a reviewer message the agent has not seen. The agent's own
+      // messages are never raced past — an interim reply postdates the delivery
+      // too, and the follow-up must land after it, not above it.
       const raced =
         author === 'agent' && seenThroughMs !== undefined
-          ? thread.messages.findIndex((m) => Date.parse(m.at) > seenThroughMs)
+          ? thread.messages.findIndex(
+              (m) => m.author === 'reviewer' && Date.parse(m.at) > seenThroughMs,
+            )
           : -1
+      // An agent reply settles the promised follow-up — unless it renews the
+      // promise. A reviewer message leaves it: the agent still owes the ending.
+      const { awaitingFollowUp: _promised, ...settled } = thread
       return {
-        ...thread,
+        ...(author === 'agent' ? settled : thread),
+        ...(author === 'agent' && followUp ? { awaitingFollowUp: true as const } : {}),
         // An agent message does NOT clear this: it proves the agent had the thread, not
         // that it saw the line you are still holding. Only a real hand-over
         // (`clearWithheld`, from Send or Finish) clears it.
@@ -199,7 +209,9 @@ export class ReviewStore {
     const threads = this.state.threads.map((thread) => {
       if (!wanted.has(thread.id) || !applies(thread)) return thread
       changed = true
-      const { unanswered: _was, ...rest } = thread
+      // Marking unanswered settles the follow-up promise too — "the agent moved
+      // on" and "a follow-up is coming" cannot both be true.
+      const { unanswered: _was, awaitingFollowUp: _promised, ...rest } = thread
       return thread.unanswered ? rest : { ...rest, unanswered: true }
     })
     if (!changed) return
@@ -208,8 +220,10 @@ export class ReviewStore {
   }
 
   setState(threadId: string, state: ThreadState): ReviewThread | null {
-    return this.update(threadId, (thread) => ({
+    return this.update(threadId, ({ awaitingFollowUp: promised, ...thread }) => ({
       ...thread,
+      // Resolving settles the promised follow-up along with the thread.
+      ...(promised && state !== 'resolved' ? { awaitingFollowUp: true as const } : {}),
       state,
       ...(state === 'sent' && !thread.sentAt ? { sentAt: new Date().toISOString() } : {}),
       // A settled thread drops its frozen diff: the snapshot keeps the thread legible
@@ -556,6 +570,11 @@ function normalizeThread(value: unknown, now: string): ReviewThread | null {
     ...(anchored ? { anchored } : {}),
     codeChanged: t.codeChanged === true,
     ...(t.unanswered === true ? { unanswered: true } : {}),
+    // Mutually exclusive with `unanswered` — a hand-edited file carrying both
+    // resolves to "the agent moved on".
+    ...(t.awaitingFollowUp === true && t.unanswered !== true
+      ? { awaitingFollowUp: true as const }
+      : {}),
     ...(t.closingNote === true ? { closingNote: true as const } : {}),
     ...(typeof t.sentAt === 'string' ? { sentAt: t.sentAt } : {}),
     messages,

--- a/src/shared/review.ts
+++ b/src/shared/review.ts
@@ -63,6 +63,11 @@ export interface ReviewThread {
   /** The agent concluded the batch this thread went out in without replying —
    * not "slow", so the UI must stop waiting on it. */
   unanswered?: boolean
+  /** The agent's last reply was posted with `--more`: an interim word, with a
+   * follow-up promised on this thread. The UI keeps waiting on the agent
+   * instead of handing the turn back. Cleared by the agent's next plain
+   * reply; downgraded to `unanswered` when the batch closes without one. */
+  awaitingFollowUp?: true
   /** The reviewer's closing note for one Finish round, kept as a thread rather
    * than as prose in the prompt: a note the agent cannot reply to is the one
    * piece of the review with no way back. Anchored to the changeset, created by

--- a/src/ui/components/Threads.tsx
+++ b/src/ui/components/Threads.tsx
@@ -54,18 +54,22 @@ function PendingReply({
   working,
   place,
   unanswered,
+  followUp,
   since,
 }: {
   working: boolean
   place?: number
   unanswered?: boolean
+  followUp?: boolean
   since?: string
 }) {
   const when = unanswered
     ? 'no answer — the agent moved on'
     : working
       ? `with the agent${since ? ` · ${timeAgo(since)}` : ''}`
-      : `queued — ${formatQueuePlace(place ?? 1)}`
+      : followUp
+        ? `follow-up on the way${since ? ` · ${timeAgo(since)}` : ''}`
+        : `queued — ${formatQueuePlace(place ?? 1)}`
   return (
     <div
       className={`cmt thread-message thread-message-agent thread-message-pending${
@@ -245,21 +249,28 @@ export function ThreadCard({
     </span>
   )
 
+  // A `--more` reply promised a follow-up: keep the typing indicator going
+  // under the interim answer instead of handing the turn back.
+  const followUp = thread.awaitingFollowUp === true
   const pendingReply =
-    working || queuePosition !== undefined || thread.unanswered ? (
+    working || queuePosition !== undefined || thread.unanswered || followUp ? (
       <PendingReply
         working={working}
         place={queuePosition}
+        followUp={followUp}
         unanswered={thread.unanswered === true && queuePosition === undefined && !working}
         since={thread.updatedAt}
       />
     ) : null
   // While the agent is composing, the indicator sits where the answer will land:
-  // after the words the delivery carried, above any the reviewer raced in since.
+  // after the words the delivery carried (its own interim reply included),
+  // above any the reviewer raced in since.
   const seenThrough =
-    working && thread.deliveredThrough ? Date.parse(thread.deliveredThrough) : null
+    (working || followUp) && thread.deliveredThrough ? Date.parse(thread.deliveredThrough) : null
   const racedAt =
-    seenThrough === null ? -1 : thread.messages.findIndex((m) => Date.parse(m.at) > seenThrough)
+    seenThrough === null
+      ? -1
+      : thread.messages.findIndex((m) => m.author === 'reviewer' && Date.parse(m.at) > seenThrough)
   const pendingAt = racedAt === -1 ? thread.messages.length : racedAt
 
   const resolveButton =

--- a/src/ui/threads.test.ts
+++ b/src/ui/threads.test.ts
@@ -133,6 +133,30 @@ describe('threadTurn', () => {
   })
 })
 
+describe('threadTurn — a promised follow-up', () => {
+  const promised = () =>
+    thread({
+      awaitingFollowUp: true,
+      messages: [msg('reviewer', 'why?'), msg('agent', 'digging in — back soon')],
+    })
+
+  it('an interim reply is a promise, not an answer — still waiting on the agent', () => {
+    expect(threadTurn(promised())).toBe('agent')
+    expect(threadOutcome(promised())).toBe('waiting')
+  })
+
+  it('the plain follow-up hands the turn back', () => {
+    const t = { ...promised(), messages: [...promised().messages, msg('agent', 'found it')] }
+    const { awaitingFollowUp: _settled, ...done } = t
+    expect(threadTurn(done)).toBe('yours')
+    expect(threadOutcome(done)).toBe('answered')
+  })
+
+  it('resolved outranks the promise — settled is settled', () => {
+    expect(threadTurn({ ...promised(), state: 'resolved' })).toBe('resolved')
+  })
+})
+
 describe('threads', () => {
   it('carries what a row needs to be recognised without opening the diff', () => {
     const [item] = threadItems([

--- a/src/ui/threads.ts
+++ b/src/ui/threads.ts
@@ -10,7 +10,10 @@ export function threadTurn(thread: ReviewThread): Turn {
   if (thread.state === 'open') return 'note'
   // Ahead of `withheld` deliberately: an answer you haven't read is hotter than a
   // follow-up you are sitting on, and the card shows the unsent reply either way.
-  if (thread.messages.at(-1)?.author === 'agent') return 'yours'
+  // A `--more` reply is a promise, not an answer: the agent still holds the turn.
+  if (thread.messages.at(-1)?.author === 'agent') {
+    return thread.awaitingFollowUp === true ? 'agent' : 'yours'
+  }
   if (thread.withheld) return 'note'
   if (!thread.unanswered) return 'agent'
   return thread.state === 'addressed' ? 'yours' : 'unanswered'
@@ -73,7 +76,8 @@ export type Outcome = 'fixed' | 'answered' | 'changed' | 'no-answer' | 'waiting'
 
 export function threadOutcome(thread: ReviewThread): Outcome | null {
   if (thread.state === 'open' || thread.state === 'resolved') return null
-  const replied = thread.messages.at(-1)?.author === 'agent'
+  // An interim (`--more`) reply doesn't count as replied — a follow-up is owed.
+  const replied = thread.messages.at(-1)?.author === 'agent' && thread.awaitingFollowUp !== true
   // `addressed` means reconcile saw the commented hunk's content-addressed id
   // rotate, i.e. the code under the comment was rewritten.
   const changed = thread.state === 'addressed'


### PR DESCRIPTION
An interim "I'll investigate and report back" reply used to read as final: the thread flipped to the reviewer's turn and the typing indicator stopped. `diffo reply --more` marks the reply as a promise instead.

- New `awaitingFollowUp` flag on the thread: the interim reply renders with the typing indicator still running beneath it, the rail keeps the thread under "Waiting on the agent", and the next plain reply settles it (another `--more` renews it).
- The thread stays on the delivery clock, so every way the agent can go quiet — re-poll, detach, dead session, server restart — downgrades the promise to the existing "no answer" state; the indicator can never run forever. A `--more` posted after an earlier plain reply re-arms the live batch.
- Finish and poll payloads treat a promised thread as still owed rather than answered; the reply ack and protocol text teach the flag.
- Fixes causal insertion to race past reviewer messages only, so the follow-up lands after the agent's own interim reply instead of above it.

Tested with 17 new unit/integration tests (989 total) plus a live end-to-end run: interim → dots stay → plain reply settles; agent death after `--more` → "no answer — the agent moved on".