### PR TITLE
fix(ui): retheme diagrams live and share the theme choice across repos

### DIFF
--- a/src/server/db.test.ts
+++ b/src/server/db.test.ts
@@ -56,7 +56,12 @@ describe('retired tables', () => {
       .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
       .all() as { name: string }[]
     inspect.close()
-    expect(tables.map((t) => t.name).sort()).toEqual(['repo_ports', 'reviews', 'servers'])
+    expect(tables.map((t) => t.name).sort()).toEqual([
+      'repo_ports',
+      'reviews',
+      'servers',
+      'ui_settings',
+    ])
     expect(second.getReview(scope)).toBe('{"kept":true}')
   })
 })
@@ -319,5 +324,24 @@ describe('remembered ports', () => {
     cleanups.push(() => second.close())
     expect(second.getPreferredPort(vanished)).toBeNull()
     expect(second.getPreferredPort(dir)).toBe(4322)
+  })
+})
+
+describe('ui settings', () => {
+  it('round-trips a setting and survives reopen — the whole point over localStorage', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'diffo-db-'))
+    cleanups.push(() => rmSync(dir, { recursive: true, force: true }))
+    const path = join(dir, 'diffo.db')
+
+    const first = new DiffoDb(path)
+    expect(first.getUiSetting('theme')).toBeNull()
+    first.setUiSetting('theme', 'dark')
+    first.setUiSetting('theme', 'light')
+    expect(first.getUiSetting('theme')).toBe('light')
+    first.close()
+
+    const second = new DiffoDb(path)
+    cleanups.push(() => second.close())
+    expect(second.getUiSetting('theme')).toBe('light')
   })
 })

--- a/src/server/db.ts
+++ b/src/server/db.ts
@@ -79,7 +79,7 @@ export class DiffoDb {
     // Retired tables are dropped, not kept. Guarded by version: if a *newer*
     // Diffo upgraded this file, its tables are not ours to judge.
     if (version <= SCHEMA_VERSION) {
-      const known = new Set(['reviews', 'servers', 'repo_ports'])
+      const known = new Set(['reviews', 'servers', 'repo_ports', 'ui_settings'])
       const tables = this.db
         .prepare("SELECT name FROM sqlite_master WHERE type = 'table' AND name NOT LIKE 'sqlite_%'")
         .all() as { name: string }[]
@@ -106,6 +106,10 @@ export class DiffoDb {
       CREATE TABLE IF NOT EXISTS repo_ports (
         repo_path TEXT PRIMARY KEY,
         port      INTEGER NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS ui_settings (
+        key   TEXT PRIMARY KEY,
+        value TEXT NOT NULL
       );
       PRAGMA user_version = ${SCHEMA_VERSION};
     `)
@@ -234,6 +238,25 @@ export class DiffoDb {
          ON CONFLICT(repo_path) DO UPDATE SET port = excluded.port`,
       )
       .run(repoPath, port)
+  }
+
+  /** Reviewer preferences that must outlive one server's origin — every repo is
+   * served from its own port, so localStorage alone can't hold a choice like
+   * the theme. Keyed blobs, no scope: these are per-human, not per-repo. */
+  getUiSetting(key: string): string | null {
+    const row = this.db.prepare('SELECT value FROM ui_settings WHERE key = ?').get(key) as
+      | { value: string }
+      | undefined
+    return row?.value ?? null
+  }
+
+  setUiSetting(key: string, value: string): void {
+    this.db
+      .prepare(
+        `INSERT INTO ui_settings (key, value) VALUES (?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value`,
+      )
+      .run(key, value)
   }
 
   getServer(repoPath: string): ServerRecord | null {

--- a/src/server/index.test.ts
+++ b/src/server/index.test.ts
@@ -57,3 +57,53 @@ describe('server', () => {
     expect(res.status).not.toBe(200)
   })
 })
+
+describe('ui settings', () => {
+  const put = (app: ReturnType<typeof createApp>, body: string) =>
+    app.request('/api/settings', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body,
+    })
+
+  const withStore = () => {
+    const kv = new Map<string, string>()
+    const app = createApp({
+      ...ctx,
+      uiSettings: {
+        get: (key) => kv.get(key) ?? null,
+        set: (key, value) => void kv.set(key, value),
+      },
+    })
+    return { app, kv }
+  }
+
+  it('answers null without a store, and refuses writes', async () => {
+    const app = createApp(ctx)
+    const res = await app.request('/api/settings')
+    expect(await res.json()).toEqual({ theme: null })
+    expect((await put(app, '{"theme":"dark"}')).status).toBe(503)
+  })
+
+  it('round-trips the shared theme', async () => {
+    const { app, kv } = withStore()
+    expect((await put(app, '{"theme":"dark"}')).status).toBe(200)
+    expect(kv.get('theme')).toBe('dark')
+    const res = await app.request('/api/settings')
+    expect(await res.json()).toEqual({ theme: 'dark' })
+  })
+
+  it('rejects a theme outside the three real values', async () => {
+    const { app, kv } = withStore()
+    expect((await put(app, '{"theme":"neon"}')).status).toBe(400)
+    expect((await put(app, 'not json')).status).toBe(400)
+    expect(kv.size).toBe(0)
+  })
+
+  it('reads a stored junk value as null, never as a theme', async () => {
+    const { app, kv } = withStore()
+    kv.set('theme', 'neon')
+    const res = await app.request('/api/settings')
+    expect(await res.json()).toEqual({ theme: null })
+  })
+})

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -82,6 +82,13 @@ const POLL_HEARTBEAT_MS = 15_000
  */
 const POLL_MAX_MS = 30 * 60_000
 
+/** Reviewer preferences shared across every repo's server — backed by the one
+ * DiffoDb, narrowed here so createApp (and its tests) never hold a database. */
+export interface UiSettings {
+  get(key: string): string | null
+  set(key: string, value: string): void
+}
+
 export interface ServerContext {
   root: string
   spec: ChangesetSpec
@@ -91,6 +98,7 @@ export interface ServerContext {
   onShutdownRequest?: () => void
   onListenError?: (err: NodeJS.ErrnoException) => void
   idle?: IdleMonitor
+  uiSettings?: UiSettings
 }
 
 export function createApp(
@@ -169,6 +177,27 @@ export function createApp(
   app.post('/api/shutdown', (c) => {
     setImmediate(() => ctx.onShutdownRequest?.())
     return c.json({ ok: true, note: 'shutting down' })
+  })
+
+  // Reviewer preferences that follow the human, not the origin: every repo is
+  // served from its own port, so a localStorage choice dies with the tab. The
+  // shared DB holds the durable copy; localStorage stays only as the
+  // before-first-paint cache.
+  const THEME_VALUES = new Set(['system', 'light', 'dark'])
+  app.get('/api/settings', (c) => {
+    const theme = ctx.uiSettings?.get('theme') ?? null
+    return c.json({ theme: theme !== null && THEME_VALUES.has(theme) ? theme : null })
+  })
+
+  app.put('/api/settings', async (c) => {
+    if (!ctx.uiSettings) return c.json({ error: 'settings unavailable' }, 503)
+    const body = await c.req.json().catch(() => null)
+    const theme: unknown = body?.theme
+    if (typeof theme !== 'string' || !THEME_VALUES.has(theme)) {
+      return c.json({ error: 'need {theme: "system" | "light" | "dark"}' }, 400)
+    }
+    ctx.uiSettings.set('theme', theme)
+    return c.json({ ok: true })
   })
 
   const repoInfo = () =>
@@ -924,6 +953,10 @@ export function startServer(options: ServerContext & { port: number }) {
       ...options,
       idle,
       onShutdownRequest: options.onShutdownRequest ?? (() => process.exit(0)),
+      uiSettings: {
+        get: (key) => db.getUiSetting(key),
+        set: (key, value) => db.setUiSetting(key, value),
+      },
     },
     store,
     review,

--- a/src/ui/mermaid.test.ts
+++ b/src/ui/mermaid.test.ts
@@ -23,9 +23,14 @@ vi.mock('beautiful-mermaid', async (importOriginal) => {
 
 import { renderMermaidIn } from './mermaid.js'
 
-// jsdom has no matchMedia; the fallback renderer's theme pick needs one.
+// jsdom has no matchMedia; the fallback renderer's theme pick needs one, and
+// the theme watcher subscribes to its change event.
 window.matchMedia = ((query: string) =>
-  ({ matches: false, media: query }) as MediaQueryList) as typeof window.matchMedia
+  ({
+    matches: false,
+    media: query,
+    addEventListener: () => {},
+  }) as unknown as MediaQueryList) as typeof window.matchMedia
 
 fallback.parse.mockImplementation(async (source: string) => {
   if (!source.includes('parses')) throw new Error('parse error')
@@ -48,6 +53,7 @@ function fence(source: string): HTMLElement {
 
 beforeEach(() => {
   document.body.innerHTML = ''
+  document.documentElement.removeAttribute('data-theme')
   vi.clearAllMocks()
 })
 
@@ -125,5 +131,31 @@ describe('renderMermaidIn', () => {
     const first = root.innerHTML
     await renderMermaidIn(root)
     expect(root.innerHTML).toBe(first)
+  })
+
+  it('re-renders a stock-mermaid figure when the theme flips', async () => {
+    // Stock mermaid bakes its palette in; the figure must be redrawn live, not
+    // wait for a reload.
+    const root = fence('pie parses\n  "a": 1')
+    await renderMermaidIn(root)
+    const figure = root.querySelector<HTMLElement>('.mermaid-figure')!
+    const before = figure.innerHTML
+    fallback.initialize.mockClear()
+    document.documentElement.setAttribute('data-theme', 'dark')
+    await vi.waitFor(() => expect(figure.innerHTML).not.toBe(before))
+    expect(fallback.initialize).toHaveBeenCalledWith(expect.objectContaining({ theme: 'dark' }))
+    expect(figure.innerHTML).toContain('data-renderer="mermaid"')
+  })
+
+  it('leaves a beautiful-mermaid figure alone on a theme flip — CSS retheming covers it', async () => {
+    const root = fence('graph LR\n  a --> b')
+    await renderMermaidIn(root)
+    const figure = root.querySelector<HTMLElement>('.mermaid-figure')!
+    expect(figure.dataset.mermaidSource).toBeUndefined()
+    const before = figure.innerHTML
+    document.documentElement.setAttribute('data-theme', 'dark')
+    // MutationObserver delivery + any (wrong) re-render would land within a tick.
+    await new Promise((r) => setTimeout(r, 20))
+    expect(figure.innerHTML).toBe(before)
   })
 })

--- a/src/ui/mermaid.ts
+++ b/src/ui/mermaid.ts
@@ -107,17 +107,7 @@ async function loadMermaid(): Promise<MermaidApi> {
   return mermaid
 }
 
-/** Render one fence's source to SVG, or null when neither renderer takes it. */
-async function renderDiagram(source: string): Promise<string | null> {
-  if (beautifulSupports(source)) {
-    try {
-      const bm = await loadBeautiful()
-      return stripFontImports(bm.renderMermaidSVG(source, BEAUTIFUL_OPTIONS))
-    } catch {
-      // Its parser covers a subset even of the types it claims — a flowchart
-      // feature it doesn't know lands here. Stock mermaid gets the next try.
-    }
-  }
+async function renderStock(source: string): Promise<string | null> {
   try {
     const mermaid = await loadMermaid()
     await mermaid.parse(source)
@@ -125,6 +115,59 @@ async function renderDiagram(source: string): Promise<string | null> {
     return svg
   } catch {
     return null
+  }
+}
+
+/** Render one fence's source to SVG, or null when neither renderer takes it.
+ * `live` says whose SVG it is: beautiful-mermaid's recolors itself through CSS
+ * variables, stock mermaid's bakes the theme in and needs a re-render to move. */
+async function renderDiagram(source: string): Promise<{ svg: string; live: boolean } | null> {
+  if (beautifulSupports(source)) {
+    try {
+      const bm = await loadBeautiful()
+      return { svg: stripFontImports(bm.renderMermaidSVG(source, BEAUTIFUL_OPTIONS)), live: true }
+    } catch {
+      // Its parser covers a subset even of the types it claims — a flowchart
+      // feature it doesn't know lands here. Stock mermaid gets the next try.
+    }
+  }
+  const svg = await renderStock(source)
+  return svg === null ? null : { svg, live: false }
+}
+
+function sanitizeSvg(svg: string): string {
+  return svgPurify.sanitize(svg, { USE_PROFILES: { svg: true, svgFilters: true } })
+}
+
+let watchingTheme = false
+
+/** Stock mermaid bakes its palette in at render time, so a figure it drew goes
+ * stale the moment the app's theme moves. Installed with the first such figure:
+ * on any theme flip — the explicit `data-theme` choice or the OS preference
+ * while following the system — every stock figure re-renders from the source
+ * kept on it. Beautiful-mermaid figures carry no source and are left alone. */
+function watchThemeForStockFigures(): void {
+  if (watchingTheme) return
+  watchingTheme = true
+  const onFlip = () => void rethemeStockFigures()
+  new MutationObserver(onFlip).observe(document.documentElement, {
+    attributes: true,
+    attributeFilter: ['data-theme'],
+  })
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', onFlip)
+}
+
+async function rethemeStockFigures(): Promise<void> {
+  // Flips can land faster than renders; a pass whose theme already matches the
+  // last initialize is the earlier flip's echo, and the newer pass covers it.
+  if (wantedTheme() === loadedTheme) return
+  const figures = document.querySelectorAll<HTMLElement>('.mermaid-figure[data-mermaid-source]')
+  for (const figure of Array.from(figures)) {
+    const svg = await renderStock(figure.dataset.mermaidSource ?? '')
+    // The source parsed once already; a null now means mermaid itself moved
+    // under us — keep the stale-themed figure rather than blanking it.
+    if (svg === null || !figure.isConnected) continue
+    figure.innerHTML = sanitizeSvg(svg)
   }
 }
 
@@ -152,10 +195,10 @@ export async function renderMermaidIn(root: HTMLElement | null): Promise<void> {
     if (pre.hasAttribute('data-mermaid-done')) continue
     pre.setAttribute('data-mermaid-done', '')
     const source = pre.textContent ?? ''
-    const svg = await renderDiagram(source)
+    const rendered = await renderDiagram(source)
     // React may have re-rendered (or unmounted) while a renderer loaded.
     if (!pre.isConnected) continue
-    if (svg === null) {
+    if (rendered === null) {
       const note = document.createElement('div')
       note.className = 'mermaid-broken'
       note.textContent = "diagram didn't parse — showing its source"
@@ -164,9 +207,11 @@ export async function renderMermaidIn(root: HTMLElement | null): Promise<void> {
     }
     const figure = document.createElement('div')
     figure.className = 'mermaid-figure'
-    figure.innerHTML = svgPurify.sanitize(svg, {
-      USE_PROFILES: { svg: true, svgFilters: true },
-    })
+    figure.innerHTML = sanitizeSvg(rendered.svg)
+    if (!rendered.live) {
+      figure.dataset.mermaidSource = source
+      watchThemeForStockFigures()
+    }
     pre.replaceWith(figure)
   }
 }

--- a/src/ui/theme.test.ts
+++ b/src/ui/theme.test.ts
@@ -1,9 +1,30 @@
 // @vitest-environment jsdom
-import { act, renderHook } from '@testing-library/react'
-import { afterEach, describe, expect, it } from 'vitest'
-import { applyTheme, loadTheme, useTheme } from './theme.js'
+import { act, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { applyTheme, fetchSharedTheme, loadTheme, useTheme } from './theme.js'
+
+/** The server side of the sync: GET answers `shared`, PUT records its body. */
+function stubSettingsApi(shared: unknown = null) {
+  const puts: unknown[] = []
+  vi.stubGlobal(
+    'fetch',
+    vi.fn(async (_url: string, init?: RequestInit) => {
+      if (init?.method === 'PUT') {
+        puts.push(JSON.parse(String(init.body)))
+        return new Response(JSON.stringify({ ok: true }))
+      }
+      return new Response(JSON.stringify({ theme: shared }))
+    }),
+  )
+  return puts
+}
+
+beforeEach(() => {
+  stubSettingsApi()
+})
 
 afterEach(() => {
+  vi.unstubAllGlobals()
   localStorage.clear()
   document.documentElement.removeAttribute('data-theme')
 })
@@ -33,6 +54,22 @@ describe('applyTheme', () => {
   })
 })
 
+describe('fetchSharedTheme', () => {
+  it('returns the server value, and null for junk or an unreachable server', async () => {
+    stubSettingsApi('dark')
+    expect(await fetchSharedTheme()).toBe('dark')
+    stubSettingsApi('neon')
+    expect(await fetchSharedTheme()).toBeNull()
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('no server')
+      }),
+    )
+    expect(await fetchSharedTheme()).toBeNull()
+  })
+})
+
 describe('useTheme', () => {
   it('setting a theme applies it and persists it', () => {
     const { result } = renderHook(() => useTheme())
@@ -48,5 +85,30 @@ describe('useTheme', () => {
     act(() => result.current[1]('system'))
     expect(document.documentElement.hasAttribute('data-theme')).toBe(false)
     expect(localStorage.getItem('diffo:ui:theme')).toBeNull()
+  })
+
+  it('adopts the server-shared choice over the local cache on mount', async () => {
+    // Chosen on another repo's port — this origin has never seen it.
+    stubSettingsApi('dark')
+    const { result } = renderHook(() => useTheme())
+    await waitFor(() => expect(result.current[0]).toBe('dark'))
+    expect(document.documentElement.getAttribute('data-theme')).toBe('dark')
+    expect(localStorage.getItem('diffo:ui:theme')).toBe('dark')
+  })
+
+  it('a set writes through to the server, so every other origin follows', async () => {
+    const puts = stubSettingsApi()
+    const { result } = renderHook(() => useTheme())
+    act(() => result.current[1]('dark'))
+    await waitFor(() => expect(puts).toEqual([{ theme: 'dark' }]))
+  })
+
+  it('keeps the local choice when the server has none', async () => {
+    localStorage.setItem('diffo:ui:theme', 'light')
+    stubSettingsApi(null)
+    const { result } = renderHook(() => useTheme())
+    // The mount fetch resolves to nothing — the state must not move.
+    await act(async () => {})
+    expect(result.current[0]).toBe('light')
   })
 })

--- a/src/ui/theme.ts
+++ b/src/ui/theme.ts
@@ -1,4 +1,4 @@
-import { useCallback, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 
 /**
  * Theme choice. Both palettes live in styles.css: light is the sheet's default, dark
@@ -8,6 +8,12 @@ import { useCallback, useState } from 'react'
  * `system` is the absence of the attribute, not a third palette — that keeps the media
  * query in charge, live. Storage mirrors it: `system` removes the key, so a fresh
  * profile and "follow the system" are the same state.
+ *
+ * Two stores, one choice. Every repo is served from its own port, so localStorage —
+ * per-origin by nature — can only cache the choice for THIS origin's next paint.
+ * The durable copy lives server-side in the shared DB (`/api/settings`), where every
+ * review on every port reads it: pick dark once, and it's dark everywhere. On mount
+ * the server's answer wins over the local cache; a set writes through to both.
  */
 
 export type Theme = 'system' | 'light' | 'dark'
@@ -16,9 +22,18 @@ export const THEMES: readonly Theme[] = ['system', 'light', 'dark']
 
 const KEY = 'diffo:ui:theme'
 
+function asTheme(raw: unknown): Theme | null {
+  return raw === 'system' || raw === 'light' || raw === 'dark' ? raw : null
+}
+
 export function loadTheme(): Theme {
   const raw = localStorage.getItem(KEY)
   return raw === 'light' || raw === 'dark' ? raw : 'system'
+}
+
+function storeTheme(theme: Theme) {
+  if (theme === 'system') localStorage.removeItem(KEY)
+  else localStorage.setItem(KEY, theme)
 }
 
 export function applyTheme(theme: Theme) {
@@ -26,13 +41,48 @@ export function applyTheme(theme: Theme) {
   else document.documentElement.setAttribute('data-theme', theme)
 }
 
+/** The choice shared across every diffo origin, or null when the server has
+ * none (or isn't reachable — a dev client without its proxy still themes). */
+export async function fetchSharedTheme(): Promise<Theme | null> {
+  try {
+    const res = await fetch('/api/settings')
+    if (!res.ok) return null
+    const body = (await res.json()) as { theme?: unknown }
+    return asTheme(body?.theme)
+  } catch {
+    return null
+  }
+}
+
+function pushSharedTheme(theme: Theme): void {
+  // Fire-and-forget: the local copy is already applied, and the next review to
+  // load asks the server again anyway.
+  void fetch('/api/settings', {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ theme }),
+  }).catch(() => {})
+}
+
 export function useTheme(): [Theme, (theme: Theme) => void] {
   const [theme, setThemeState] = useState<Theme>(loadTheme)
+  useEffect(() => {
+    let cancelled = false
+    void fetchSharedTheme().then((shared) => {
+      if (cancelled || shared === null || shared === loadTheme()) return
+      storeTheme(shared)
+      applyTheme(shared)
+      setThemeState(shared)
+    })
+    return () => {
+      cancelled = true
+    }
+  }, [])
   const setTheme = useCallback((next: Theme) => {
     setThemeState(next)
     applyTheme(next)
-    if (next === 'system') localStorage.removeItem(KEY)
-    else localStorage.setItem(KEY, next)
+    storeTheme(next)
+    pushSharedTheme(next)
   }, [])
   return [theme, setTheme]
 }


### PR DESCRIPTION
Two theme bugs:

**Diagrams went stale on a theme switch.** beautiful-mermaid figures follow the
theme live through CSS variables, but anything that falls back to stock mermaid
(pie, gantt, unsupported flowchart features) bakes its palette in at render
time and only caught up after a refresh. Each stock-rendered figure now keeps
its fence source, and a watcher on `data-theme` / `prefers-color-scheme`
re-renders those figures in place on every flip.

**The theme choice didn't stick.** It lived only in localStorage, which is
per-origin — and every repo is served from its own port, so picking dark in one
review never reached the next. The durable copy now lives in a `ui_settings`
table in the shared DB behind `GET/PUT /api/settings`: the client adopts the
server's answer on mount and writes through on change, with localStorage kept
as the before-first-paint cache.

Tested: unit tests for the retheme pass, the settings endpoints, the DB
round-trip, and the client sync; verified live in the browser (theme flip
redraws a pie diagram in place; a reload with cleared localStorage comes back
with the server's choice).