### PR TITLE
release: 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,38 @@ Until 1.0, minor versions may break things. When they do, the entry says how to 
 
 ## [Unreleased]
 
+Nothing yet.
+
+## [0.2.0] — 2026-08-31
+
+### Added
+
+- **Diagrams in comments render beautifully.** Mermaid fences for the common
+  types (flowchart, sequence, state, class, ER, xychart) now render through
+  beautiful-mermaid, themed with Diffo's own CSS variables so they re-color
+  live when the theme flips. Stock mermaid remains the fallback for
+  everything else (pie, gantt, gitGraph, …) — and those now re-render in
+  place on a theme switch too, instead of keeping a stale palette until
+  refresh. Nothing that rendered before stops rendering, and all diagram
+  output still passes through the sanitizer.
+- **Interim agent replies: `diffo reply --more`.** An answer that only
+  promises a follow-up ("I'll investigate and report back") used to read as
+  final. `--more` marks it interim: the typing indicator keeps running
+  beneath it, the rail keeps the thread under "Waiting on the agent", and
+  the agent's next plain reply settles it. Every way the agent can go quiet
+  (detach, dead session, server restart) converts the promise into the
+  ordinary unanswered state, so the indicator can never run forever.
+- **Your theme choice follows you across repos.** It was stored per-origin,
+  and every repo serves from its own port — picking dark in one review never
+  reached the next. The durable copy now lives in the shared DB.
+
+### Fixed
+
+- **The reading pane now renders files in the rail's tree order** (folders
+  first, then files, alphabetical by basename) instead of raw git order, so
+  the pane, J/K navigation, "next unreviewed", and the finish-review
+  coverage lists all read in the order the rail shows.
+
 ### Changed
 
 - **The review loop spends far fewer of the agent's tokens.** The full
@@ -148,7 +180,8 @@ shipped in it, written as a starting point rather than a history.
 - **Guided reading** — splitting a large change into an ordered sequence of small,
   reviewable sections — is designed but not built.
 
-[Unreleased]: https://github.com/DiffoHQ/diffo/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/DiffoHQ/diffo/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/DiffoHQ/diffo/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/DiffoHQ/diffo/compare/v0.0.2...v0.1.0
 [0.0.2]: https://github.com/DiffoHQ/diffo/compare/v0.0.1...v0.0.2
 [0.0.1]: https://github.com/DiffoHQ/diffo

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@diffohq/diffo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Local, live code review for the AI age — read what the agent wrote and send feedback straight back",
   "type": "module",
   "license": "Apache-2.0",

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "diffo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Local, live code review for the AI age — read what the agent wrote and send feedback straight back",
   "author": {
     "name": "DiffoHQ",


### PR DESCRIPTION
0.1.0 → 0.2.0 — minor: adds diagram rendering via beautiful-mermaid, interim
agent replies (`diffo reply --more`), and a cross-repo theme choice.
- Bumps package.json + plugin.json to 0.2.0.
- CHANGELOG: retitles [Unreleased] → [0.2.0] — 2026-08-31, and adds the
  entries #43–#46 landed without (diagrams, --more, theme sharing, reading
  pane order).
- `pnpm check` green locally; SKILL.md rebuild produced no diff.