### PR TITLE
docs: refresh the test count, swap the pre-release badge, add a star CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ come back as fixes.
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue)](LICENSE)
 [![Node](https://img.shields.io/badge/node-%E2%89%A5%2024-brightgreen)](#quick-start)
 [![Docs](https://img.shields.io/badge/docs-diffo-8b5cf6)](https://diffohq.github.io/diffo/)
-[![Status](https://img.shields.io/badge/status-pre--release-orange)](#status)
+[![Tests](https://img.shields.io/badge/tests-1000-brightgreen)](#contributing)
 
 </div>
 
@@ -214,7 +214,7 @@ cheapest to change.
 TypeScript on Node >= 24: a [Hono](https://hono.dev) server over loopback serving a React 19
 UI, live updates over server-sent events from one recursive filesystem watch, and state in a
 single SQLite file at `~/.diffo/diffo.db` through the runtime's built-in `node:sqlite`, so
-there is no database to install. **Zero network calls.** 859 tests across 54 files.
+there is no database to install. **Zero network calls.** 1,000 tests across 57 files.
 
 Reviews are scoped per repo **and branch**, and the server is loopback-only, rejecting
 non-loopback `Host` and `Origin` headers so a web page can't reach into your repo through

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ hero:
       text: Your first review
       link: /tutorial
     - theme: alt
-      text: View on GitHub
+      text: ★ Star on GitHub
       link: https://github.com/DiffoHQ/diffo
 
 features:


### PR DESCRIPTION
Three independent text edits. No logic, no behaviour change.

### 1. The test count was stale

`README.md` claimed `859 tests across 54 files`. The suite is at **1,000 across 57** — the README was underselling by 141 tests.

Verified on this tree, not taken on trust:

```
Test Files  56 passed | 1 skipped (57)
     Tests  1000 passed | 9 skipped (1009)
```

### 2. The `pre-release` badge

Swapped for a tests badge:

```diff
-[![Status](https://img.shields.io/badge/status-pre--release-orange)](#status)
+[![Tests](https://img.shields.io/badge/tests-1000-brightgreen)](#contributing)
```

The badge was honest, and it stays honest — the **Status** section still says Diffo is pre-1.0 with the edges moving, addressed to a reader who has the context by the time they get there. As a badge it was the only element above the fold arguing against the product, to people who hadn't seen it yet. This puts a proof point in the same pixel.

**The Status section is unchanged.** That is what makes this a swap rather than a cover-up.

### 3. The docs hero had no star CTA

`docs/index.md`, the `theme: alt` action: `View on GitHub` → `★ Star on GitHub`. The `link` is untouched.

---

### Verification

`pnpm check` — all five gates — exits **0**: typecheck, test, build, lint, docs:build.

One pre-existing note, unrelated to this change: `biome` reports `1 info` for a `$schema` version mismatch in `biome.json` (`2.5.9` declared, CLI is `2.5.11`). It was there before and does not fail the gate.

### Known follow-up

The new badge hardcodes `1000`, so it inherits exactly the drift this PR just fixed in the prose. A shields.io endpoint or a CI step that rewrites the number would hold it; left out deliberately to keep this diff to three lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)